### PR TITLE
Base the compilation on the result of the linker front-end.

### DIFF
--- a/wasm/src/main/scala/Compiler.scala
+++ b/wasm/src/main/scala/Compiler.scala
@@ -10,35 +10,97 @@ import org.scalajs.ir
 import org.scalajs.ir.Trees._
 import org.scalajs.ir.Types._
 
+import org.scalajs.linker.frontend.LinkerFrontendImpl
 import org.scalajs.linker.interface.IRFile
-import org.scalajs.linker.interface.unstable.IRFileImpl
+import org.scalajs.linker.standard.{LinkedClass, SymbolRequirement}
+
+import org.scalajs.logging.{Level, ScalaConsoleLogger}
 
 import scala.concurrent.{ExecutionContext, Future}
 import _root_.ir2wasm.Preprocessor
 
 object Compiler {
   def compileIRFiles(irFiles: Seq[IRFile])(implicit ec: ExecutionContext): Future[Unit] = {
-    // IRFileImpl.fromIRFile()
     val module = new WasmModule
     val builder = new WasmBuilder()
     implicit val context: WasmContext = new WasmContext(module)
     println("compiling")
-    val filtered = irFiles.filter { i =>
-      val path = IRFileImpl.fromIRFile(i).path
-      path.contains("java/lang/Object") || path.contains("/sample/")
-    }
-    Future
-      .traverse(filtered)(i => IRFileImpl.fromIRFile(i).tree)
-      .map { classDefs =>
-        classDefs.foreach { clazz =>
-          Preprocessor.preprocess(clazz)(context)
+
+    val config = LinkerFrontendImpl.Config()
+      .withOptimizer(false)
+    val linkerFrontend = LinkerFrontendImpl(config)
+
+    val symbolRequirements = SymbolRequirement.factory("none").none()
+    val logger = new ScalaConsoleLogger(Level.Error)
+
+    linkerFrontend.link(irFiles, Nil, symbolRequirements, logger)
+      .map { moduleSet =>
+        val onlyModule = moduleSet.modules.head
+
+        val filteredClasses = onlyModule.classDefs.filter { c =>
+          c.className == ir.Names.ObjectClass || c.className.nameString.startsWith("sample.")
         }
-        classDefs.foreach { clazz =>
-          println(clazz.show)
+
+        filteredClasses.sortBy(_.className).foreach(showLinkedClass(_))
+
+        Preprocessor.preprocess(filteredClasses)(context)
+        filteredClasses.foreach { clazz =>
           builder.transformClassDef(clazz)
+        }
+        onlyModule.topLevelExports.foreach { tle =>
+          builder.transformTopLevelExport(tle)
         }
         val writer = new converters.WasmTextWriter()
         println(writer.write(module))
       }
+  }
+
+  private def showLinkedClass(clazz: LinkedClass): Unit = {
+    val writer = new java.io.PrintWriter(System.out)
+    val printer = new LinkedClassPrinter(writer)
+    printer.print(clazz)
+    printer.println()
+    writer.flush()
+  }
+
+  private class LinkedClassPrinter(_out: java.io.Writer) extends ir.Printers.IRTreePrinter(_out) {
+    def print(clazz: LinkedClass): Unit = {
+      print("linked ")
+      print(clazz.kind.toString())
+      print(" ")
+      print(clazz.className)
+      clazz.superClass.foreach { cls =>
+        print(" extends ")
+        print(cls)
+        clazz.jsSuperClass.foreach { tree =>
+          print(" (via ")
+          print(tree)
+          print(")")
+        }
+      }
+      if (clazz.interfaces.nonEmpty) {
+        print(" implements ")
+        var rest = clazz.interfaces
+        while (rest.nonEmpty) {
+          print(rest.head)
+          rest = rest.tail
+          if (rest.nonEmpty)
+            print(", ")
+        }
+      }
+      clazz.jsNativeLoadSpec.foreach { spec =>
+        print(" loadfrom ")
+        print(spec)
+      }
+      print(" ")
+      printColumn(
+        clazz.fields
+          ::: clazz.methods
+          ::: clazz.jsConstructorDef.toList
+          ::: clazz.exportedMembers
+          ::: clazz.jsNativeMembers,
+        "{", "", "}"
+      )
+    }
   }
 }

--- a/wasm/src/main/scala/Main.scala
+++ b/wasm/src/main/scala/Main.scala
@@ -41,7 +41,8 @@ object Main {
     val builder = new WasmBuilder()
     implicit val context: WasmContext = new WasmContext(module)
     basicTestClassDefs.foreach { clazz =>
-      builder.transformClassDef(clazz)
+      //builder.transformClassDef(clazz)
+      ???
     }
     val writer = new converters.WasmTextWriter()
     println(writer.write(module))


### PR DESCRIPTION
Instead of manipulating raw `ClassDef`s, we now first invoke the standard linker front-end to get a set of `LinkedClass`es. This way, we benefit from the existing reachability analysis and method synthesis (such as default method bridges).

One drawback is that abstract methods are removed from `LinkedClass`es, including in interfaces. We recover the ones we need with an additional pre-processing pass.