### PR TITLE
Elementary infrastructure for strings.

### DIFF
--- a/wasm/src/main/scala/Compiler.scala
+++ b/wasm/src/main/scala/Compiler.scala
@@ -70,6 +70,8 @@ object Compiler {
       Set(
         ClassClass, // java.lang.Class
         ClassName("java.lang.FloatingPointBits$")
+      ) -- Set(
+        BoxedBooleanClass.withSuffix("$")
       )
   }
 

--- a/wasm/src/main/scala/Compiler.scala
+++ b/wasm/src/main/scala/Compiler.scala
@@ -43,7 +43,7 @@ object Compiler {
         val onlyModule = moduleSet.modules.head
 
         val filteredClasses = onlyModule.classDefs.filter { c =>
-          c.className == ir.Names.ObjectClass || c.className.nameString.startsWith("sample.")
+          !ExcludedClasses.contains(c.className)
         }
 
         filteredClasses.sortBy(_.className).foreach(showLinkedClass(_))
@@ -61,6 +61,16 @@ object Compiler {
         val binaryOutput = new converters.WasmBinaryWriter(module).write()
         FS.writeFileSync("./target/output.wasm", binaryOutput.toTypedArray)
       }
+  }
+
+  private val ExcludedClasses: Set[ir.Names.ClassName] = {
+    import ir.Names._
+    HijackedClasses ++ // hijacked classes
+      HijackedClasses.map(_.withSuffix("$")) ++ // their companions
+      Set(
+        ClassClass, // java.lang.Class
+        ClassName("java.lang.FloatingPointBits$")
+      )
   }
 
   private def showLinkedClass(clazz: LinkedClass): Unit = {

--- a/wasm/src/main/scala/converters/WasmBinaryWriter.scala
+++ b/wasm/src/main/scala/converters/WasmBinaryWriter.scala
@@ -144,7 +144,7 @@ final class WasmBinaryWriter(module: WasmModule) {
     }
   }
 
-  private def writeType(buf: Buffer, typ: WasmType): Unit = {
+  private def writeType(buf: Buffer, typ: WasmStorageType): Unit = {
     buf.byte(typ.code)
     typ match {
       case WasmRefNullType(heapType) => writeHeapType(buf, heapType)

--- a/wasm/src/main/scala/ir2wasm/TypeTransformer.scala
+++ b/wasm/src/main/scala/ir2wasm/TypeTransformer.scala
@@ -58,14 +58,24 @@ object TypeTransformer {
         // Types.WasmRefType(Types.WasmHeapType.Type(arrayTySym))
         ???
       case clazz @ IRTypes.ClassType(className) =>
-        if (ctx.getClassInfo(clazz.className).isInterface)
-          Types.WasmRefNullType(Types.WasmHeapType.ObjectType)
-        else
-          Types.WasmRefType(
-            Types.WasmHeapType.Type(Names.WasmTypeName.WasmStructTypeName(className))
-          )
+        className match {
+          case IRNames.BoxedStringClass =>
+            Types.WasmRefNullType(
+              Types.WasmHeapType.Type(Names.WasmTypeName.WasmStructTypeName.string)
+            )
+          case _ =>
+            if (ctx.getClassInfo(clazz.className).isInterface)
+              Types.WasmRefNullType(Types.WasmHeapType.ObjectType)
+            else
+              Types.WasmRefType(
+                Types.WasmHeapType.Type(Names.WasmTypeName.WasmStructTypeName(className))
+              )
+        }
       case IRTypes.RecordType(fields) => ???
-      case IRTypes.StringType         => ??? // TODO
+      case IRTypes.StringType =>
+        Types.WasmRefType(
+          Types.WasmHeapType.Type(Names.WasmTypeName.WasmStructTypeName.string)
+        )
       case IRTypes.UndefType          => ???
       case p: IRTypes.PrimTypeWithRef => transformPrimType(p)
     }

--- a/wasm/src/main/scala/wasm4s/Names.scala
+++ b/wasm/src/main/scala/wasm4s/Names.scala
@@ -113,6 +113,7 @@ object Names {
     val vtable = new WasmFieldName("vtable")
     val itable = new WasmFieldName("itable")
     val itables = new WasmFieldName("itables")
+    val stringData = new WasmFieldName("string_data")
   }
 
   // GC types ====
@@ -125,6 +126,7 @@ object Names {
     }
     object WasmStructTypeName {
       def apply(name: IRNames.ClassName) = new WasmStructTypeName(name.nameString)
+      val string = new WasmStructTypeName("string")
     }
 
     /** Array type's name */
@@ -137,6 +139,7 @@ object Names {
         new WasmArrayTypeName(s"${ref.base.displayName}_${ref.dimensions}")
       }
       val itables = new WasmArrayTypeName("itable")
+      val stringData = new WasmArrayTypeName("string_data")
     }
 
     final case class WasmFunctionTypeName private (override private[wasm4s] val name: String)

--- a/wasm/src/main/scala/wasm4s/Types.scala
+++ b/wasm/src/main/scala/wasm4s/Types.scala
@@ -5,12 +5,14 @@ import Names._
 import Names.WasmTypeName._
 
 object Types {
-  abstract sealed class WasmType(
+  abstract sealed class WasmStorageType(
       private val name: String,
       val code: Byte
   ) {
     def show: String = name
   }
+
+  abstract sealed class WasmType(name: String, code: Byte) extends WasmStorageType(name, code)
 
   // todo
   case object WasmNoType extends WasmType("", 0x00)
@@ -22,8 +24,10 @@ object Types {
   case object WasmFloat32 extends WasmType("f32", 0x7D)
   case object WasmFloat64 extends WasmType("f64", 0x7C)
   // case object WasmVec128 extends WasmType("v128", -0x5)
-  // case object WasmInt8 extends WasmType("i8", -0x6)
-  // case object WasmInt16 extends WasmType("i16", -0x7)
+
+  sealed abstract class WasmPackedType(name: String, code: Byte) extends WasmStorageType(name, code)
+  case object WasmInt8 extends WasmPackedType("i8", 0x78)
+  case object WasmInt16 extends WasmPackedType("i16", 0x77)
 
   // shorthands
   // https://github.com/WebAssembly/gc/blob/main/proposals/gc/MVP.md#reference-types-1

--- a/wasm/src/main/scala/wasm4s/Wasm.scala
+++ b/wasm/src/main/scala/wasm4s/Wasm.scala
@@ -72,6 +72,15 @@ case class WasmStructType(
     fields: List[WasmStructField],
     superType: Option[WasmTypeName]
 ) extends WasmGCTypeDefinition
+object WasmStructType {
+  val string: WasmStructType = WasmStructType(
+    WasmTypeName.WasmStructTypeName.string,
+    List(
+      WasmStructField(WasmFieldName.stringData, WasmRefType(WasmHeapType.Type(WasmArrayTypeName.stringData)), false)
+    ),
+    None
+  )
+}
 
 case class WasmArrayType(
     name: WasmTypeName,
@@ -84,11 +93,16 @@ object WasmArrayType {
     WasmStructField(WasmFieldName.itable, WasmRefType(WasmHeapType.Simple.Struct), false)
   )
 
+  /** array i16 */
+  val stringData = WasmArrayType(
+    WasmArrayTypeName.stringData,
+    WasmStructField(WasmFieldName.stringData, WasmInt16, false)
+  )
 }
 
 case class WasmStructField(
     name: WasmFieldName,
-    typ: WasmType,
+    typ: WasmStorageType,
     isMutable: Boolean
 )
 object WasmStructField {
@@ -130,10 +144,12 @@ class WasmModule(
 
   def functionTypes = _functionTypes.toList
   def recGroupTypes = WasmModule.tsort(_recGroupTypes.toList)
-  def arrayTypes = List(WasmArrayType.itables)
+  def arrayTypes = List(WasmArrayType.itables, WasmArrayType.stringData)
   def definedFunctions = _definedFunctions.toList
   def globals = _globals.toList
   def exports = _exports.toList
+
+  addRecGroupType(WasmStructType.string)
 }
 
 object WasmModule {


### PR DESCRIPTION
We introduce the global type `$string` as a typed struct containing a reference to an array of `i16`. We add support for loading string constants, and for converting primitive booleans to strings.

This is the minimum amount of support required to remove `java.lang.Boolean$` from the excluded list. Its `toString(b: bool)` method performs `"" String_+ b`.

This encoding of strings is hopefully temporary. Ideally we will want to use a Wasm `stringref` instead.