### PR TITLE
Directly write the binary .wasm format to `target/output.wasm`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,18 @@
 
 ### Usage
 
-- `sample/run` to compile `sample/src/main/scala/Sample.scala` to WebAssembly Text Format (WAT) (Stack IR form)
-- Copy and paste the output WAT to a file, and transform it to binary using WasmGC reference interpreter.
-  - https://github.com/WebAssembly/gc/tree/main/interpreter
-  - Use docker image for it https://github.com/tanishiking/wasmgc-docker
+- `sample/run` to compile `sample/src/main/scala/Sample.scala`.
+  - prints the WebAssembly Text Format (WAT) (Stack IR form) to the console, for debugging
+  - writes the binary format (WASM) to `target/output.wasm`
 
-
-Run the binary using Deno or something (`run.mjs`).
-
-```js
-import { readFileSync } from "node:fs";
-const wasmBuffer = readFileSync("test.wasm");
-const wasmModule = await WebAssembly.instantiate(wasmBuffer);
-const { bar } = wasmModule.instance.exports;
-const o = bar(100);
-console.log(o);
-```
+Run the binary using through `run.js` using a JavaScript engine that supports WasmGC, such as Deno
 
 ```sh
 $ deno run --allow-read run.mjs
 ```
 
+### Debugging tools
 
+- The WasmGC reference interpreter can be used to validate and convert between the binary and text form:
+  - https://github.com/WebAssembly/gc/tree/main/interpreter
+  - Use docker image for it https://github.com/tanishiking/wasmgc-docker

--- a/run.mjs
+++ b/run.mjs
@@ -1,0 +1,6 @@
+import { readFileSync } from "node:fs";
+const wasmBuffer = readFileSync("./target/output.wasm");
+const wasmModule = await WebAssembly.instantiate(wasmBuffer);
+const { test } = wasmModule.instance.exports;
+const o = test();
+console.log(o);

--- a/wasm/src/main/scala/Compiler.scala
+++ b/wasm/src/main/scala/Compiler.scala
@@ -17,6 +17,11 @@ import org.scalajs.linker.standard.{LinkedClass, SymbolRequirement}
 import org.scalajs.logging.{Level, ScalaConsoleLogger}
 
 import scala.concurrent.{ExecutionContext, Future}
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+import scala.scalajs.js.typedarray._
+
 import _root_.ir2wasm.Preprocessor
 
 object Compiler {
@@ -52,6 +57,9 @@ object Compiler {
         }
         val writer = new converters.WasmTextWriter()
         println(writer.write(module))
+
+        val binaryOutput = new converters.WasmBinaryWriter(module).write()
+        FS.writeFileSync("./target/output.wasm", binaryOutput.toTypedArray)
       }
   }
 
@@ -102,5 +110,10 @@ object Compiler {
         "{", "", "}"
       )
     }
+  }
+
+  private object FS {
+    @js.native @JSImport("fs")
+    def writeFileSync(file: String, data: Int8Array): Unit = js.native
   }
 }

--- a/wasm/src/main/scala/converters/WasmBinaryWriter.scala
+++ b/wasm/src/main/scala/converters/WasmBinaryWriter.scala
@@ -1,0 +1,368 @@
+package wasm
+package converters
+
+import scala.annotation.tailrec
+
+import java.io.OutputStream
+import java.io.ByteArrayOutputStream
+
+import wasm.wasm4s._
+import wasm.wasm4s.Names._
+import wasm.wasm4s.Types._
+import wasm.wasm4s.Types.WasmHeapType.Type
+import wasm.wasm4s.Types.WasmHeapType.Func
+import wasm.wasm4s.Types.WasmHeapType.Simple
+import wasm.wasm4s.WasmInstr.END
+
+final class WasmBinaryWriter(module: WasmModule) {
+  import WasmBinaryWriter._
+
+  private val allTypeDefinitions: List[WasmTypeDefinition[_ <: WasmTypeName]] = {
+    module.recGroupTypes :::
+      module.functionTypes :::
+      module.arrayTypes
+  }
+
+  private val typeIdxValues: Map[WasmTypeName, Int] =
+    allTypeDefinitions.map(_.name).zipWithIndex.toMap
+
+  private val funcIdxValues: Map[WasmFunctionName, Int] =
+    module.definedFunctions.map(_.name).zipWithIndex.toMap
+
+  private val globalIdxValues: Map[WasmGlobalName, Int] =
+    module.globals.map(_.name).zipWithIndex.toMap
+
+  private var localIdxValues: Option[Map[WasmLocalName, Int]] = None
+  private var labelsInScope: List[Option[WasmImmediate.LabelIdx]] = Nil
+
+  private def withLocalIdxValues(values: Map[WasmLocalName, Int])(f: => Unit): Unit = {
+    val saved = localIdxValues
+    localIdxValues = Some(values)
+    try f
+    finally localIdxValues = saved
+  }
+
+  def write(): Array[Byte] = {
+    val fullOutput = new Buffer()
+
+    // magic header: null char + "asm"
+    fullOutput.byte(0)
+    fullOutput.byte('a')
+    fullOutput.byte('s')
+    fullOutput.byte('m')
+
+    // version
+    fullOutput.byte(1)
+    fullOutput.byte(0)
+    fullOutput.byte(0)
+    fullOutput.byte(0)
+
+    writeSection(fullOutput, SectionType)(writeTypeSection(_))
+    writeSection(fullOutput, SectionFunction)(writeFunctionSection(_))
+    writeSection(fullOutput, SectionGlobal)(writeGlobalSection(_))
+    writeSection(fullOutput, SectionExport)(writeExportSection(_))
+    writeSection(fullOutput, SectionCode)(writeCodeSection(_))
+
+    fullOutput.result()
+  }
+
+  private def writeSection(fullOutput: Buffer, sectionID: Byte)(f: Buffer => Unit): Unit = {
+    fullOutput.byte(sectionID)
+    fullOutput.byteLengthSubSection(f)
+  }
+
+  private def writeTypeSection(buf: Buffer): Unit = {
+    buf.u32(1) // a single `rectype`
+    buf.byte(0x4E) // `rectype` tag
+    buf.u32(typeIdxValues.size) // number of `subtype`s in our single `rectype`
+
+    def writeFieldType(field: WasmStructField): Unit = {
+      writeType(buf, field.typ)
+      buf.boolean(field.isMutable)
+    }
+
+    for (typeDef <- allTypeDefinitions) {
+      typeDef match {
+        case WasmArrayType(name, field) =>
+          buf.byte(0x5E) // array
+          writeFieldType(field)
+        case WasmStructType(name, fields, superType) =>
+          buf.byte(0x50) // sub
+          buf.opt(superType)(writeTypeIdx(buf, _))
+          buf.byte(0x5F) // struct
+          buf.vec(fields)(writeFieldType(_))
+        case WasmFunctionType(name, params, results) =>
+          buf.byte(0x60) // func
+          writeResultType(buf, params)
+          writeResultType(buf, results)
+      }
+    }
+  }
+
+  private def writeFunctionSection(buf: Buffer): Unit = {
+    buf.vec(module.definedFunctions) { fun =>
+      writeTypeIdx(buf, fun.typ.name)
+    }
+  }
+
+  private def writeGlobalSection(buf: Buffer): Unit = {
+    buf.vec(module.globals) { global =>
+      writeType(buf, global.typ)
+      buf.boolean(global.isMutable)
+      writeExpr(buf, global.init)
+    }
+  }
+
+  private def writeExportSection(buf: Buffer): Unit = {
+    buf.vec(module.exports) { exp =>
+      buf.name(exp.name)
+      exp match {
+        case exp: WasmExport.Function =>
+          buf.byte(0x00)
+          writeFuncIdx(buf, exp.field.name)
+        case exp: WasmExport.Global =>
+          buf.byte(0x03)
+          writeGlobalIdx(buf, exp.field.name)
+      }
+    }
+  }
+
+  private def writeCodeSection(buf: Buffer): Unit = {
+    buf.vec(module.definedFunctions) { func =>
+      buf.byteLengthSubSection(writeFunc(_, func))
+    }
+  }
+
+  private def writeFunc(buf: Buffer, func: WasmFunction): Unit = {
+    buf.vec(func.locals.filter(!_.isParameter)) { local =>
+      buf.u32(1)
+      writeType(buf, local.typ)
+    }
+
+    withLocalIdxValues(func.locals.map(_.name).zipWithIndex.toMap) {
+      writeExpr(buf, func.body)
+    }
+  }
+
+  private def writeType(buf: Buffer, typ: WasmType): Unit = {
+    buf.byte(typ.code)
+    typ match {
+      case WasmRefNullType(heapType) => writeHeapType(buf, heapType)
+      case WasmRefType(heapType)     => writeHeapType(buf, heapType)
+      case _                         => ()
+    }
+  }
+
+  private def writeHeapType(buf: Buffer, heapType: WasmHeapType): Unit = {
+    heapType match {
+      case Type(typeName)   => writeTypeIdxs33(buf, typeName)
+      case Func(typeName)   => writeTypeIdxs33(buf, typeName)
+      case heapType: Simple => buf.byte(heapType.code)
+    }
+  }
+
+  private def writeResultType(buf: Buffer, resultType: List[WasmType]): Unit =
+    buf.vec(resultType)(writeType(buf, _))
+
+  private def writeTypeIdx(buf: Buffer, typeName: WasmTypeName): Unit =
+    buf.u32(typeIdxValues(typeName))
+
+  private def writeTypeIdxs33(buf: Buffer, typeName: WasmTypeName): Unit =
+    buf.s33OfUInt(typeIdxValues(typeName))
+
+  private def writeFuncIdx(buf: Buffer, funcName: WasmFunctionName): Unit =
+    buf.u32(funcIdxValues(funcName))
+
+  private def writeGlobalIdx(buf: Buffer, globalName: WasmGlobalName): Unit =
+    buf.u32(globalIdxValues(globalName))
+
+  private def writeLocalIdx(buf: Buffer, localName: WasmLocalName): Unit = {
+    localIdxValues match {
+      case Some(values) => buf.u32(values(localName))
+      case None         => throw new IllegalStateException(s"Local name table is not available")
+    }
+  }
+
+  private def writeLabelIdx(buf: Buffer, labelIdx: WasmImmediate.LabelIdx): Unit = {
+    val relativeNumber = labelsInScope.indexOf(Some(labelIdx))
+    if (relativeNumber < 0)
+      throw new IllegalStateException(s"Cannot find $labelIdx in scope")
+    buf.u32(relativeNumber)
+  }
+
+  private def writeExpr(buf: Buffer, expr: WasmExpr): Unit = {
+    for (instr <- expr.instr)
+      writeInstr(buf, instr)
+    buf.byte(0x0B) // end
+  }
+
+  private def writeInstr(buf: Buffer, instr: WasmInstr): Unit = {
+    val opcode = instr.opcode
+    if (opcode <= 0xff) {
+      buf.byte(opcode.toByte)
+    } else {
+      assert(opcode <= 0xffff, s"cannot encode an opcode longer than 2 bytes yet: ${opcode.toHexString}")
+      buf.byte((opcode >>> 8).toByte)
+      buf.byte(opcode.toByte)
+    }
+
+    for (immediate <- instr.immediates)
+      writeImmediate(buf, immediate)
+
+    instr match {
+      case instr: WasmInstr.StructuredLabeledInstr =>
+        // We must register even the `None` labels, because they contribute to relative numbering
+        labelsInScope ::= instr.label
+      case END =>
+        labelsInScope = labelsInScope.tail
+      case _ =>
+        ()
+    }
+  }
+
+  private def writeImmediate(buf: Buffer, immediate: WasmImmediate): Unit = {
+    import WasmImmediate._
+
+    immediate match {
+      case I32(value) => buf.i32(value)
+      case I64(value) => buf.i64(value)
+      case F32(value) => buf.f32(value)
+      case F64(value) => buf.f64(value)
+
+      case MemArg(offset, align) =>
+        buf.u32(offset.toInt)
+        buf.u32(align.toInt)
+
+      case BlockType.ValueType(None)        => buf.byte(0x40)
+      case BlockType.ValueType(Some(typ))   => writeType(buf, typ)
+      case BlockType.FunctionType(typeName) => writeTypeIdxs33(buf, typeName)
+
+      case FuncIdx(value)        => writeFuncIdx(buf, value)
+      case labelIdx: LabelIdx    => writeLabelIdx(buf, labelIdx)
+      case LabelIdxVector(value) => ???
+      case TypeIdx(value)        => writeTypeIdx(buf, value)
+      case TableIdx(value)       => ???
+      case TagIdx(value)         => ???
+      case LocalIdx(value)       => writeLocalIdx(buf, value)
+      case GlobalIdx(value)      => writeGlobalIdx(buf, value)
+      case HeapType(value)       => writeHeapType(buf, value)
+      case StructFieldIdx(value) => buf.u32(value)
+    }
+  }
+}
+
+object WasmBinaryWriter {
+  private final val SectionType = 0x01
+  private final val SectionImport = 0x02
+  private final val SectionFunction = 0x03
+  private final val SectionTable = 0x04
+  private final val SectionMemory = 0x05
+  private final val SectionGlobal = 0x06
+  private final val SectionExport = 0x07
+  private final val SectionStart = 0x08
+  private final val SectionElement = 0x09
+  private final val SectionCode = 0x0A
+  private final val SectionData = 0x0B
+  private final val SectionDataCount = 0x0C
+
+  private final class Buffer {
+    private val buf = new java.io.ByteArrayOutputStream()
+
+    def result(): Array[Byte] = buf.toByteArray()
+
+    def byte(b: Byte): Unit =
+      buf.write(b & 0xff)
+
+    def rawByteArray(array: Array[Byte]): Unit =
+      buf.write(array)
+
+    def boolean(b: Boolean): Unit =
+      byte(if (b) 1 else 0)
+
+    def u32(value: Int): Unit = unsignedLEB128(Integer.toUnsignedLong(value))
+
+    def s32(value: Int): Unit = signedLEB128(value.toLong)
+
+    def i32(value: Int): Unit = s32(value)
+
+    def s33OfUInt(value: Int): Unit = signedLEB128(Integer.toUnsignedLong(value))
+
+    def u64(value: Long): Unit = unsignedLEB128(value)
+
+    def s64(value: Long): Unit = signedLEB128(value)
+
+    def i64(value: Long): Unit = s64(value)
+
+    def f32(value: Float): Unit = {
+      val bits = java.lang.Float.floatToIntBits(value)
+      byte(bits.toByte)
+      byte((bits >>> 8).toByte)
+      byte((bits >>> 16).toByte)
+      byte((bits >>> 24).toByte)
+    }
+
+    def f64(value: Double): Unit = {
+      val bits = java.lang.Double.doubleToLongBits(value)
+      byte(bits.toByte)
+      byte((bits >>> 8).toByte)
+      byte((bits >>> 16).toByte)
+      byte((bits >>> 24).toByte)
+      byte((bits >>> 32).toByte)
+      byte((bits >>> 40).toByte)
+      byte((bits >>> 48).toByte)
+      byte((bits >>> 56).toByte)
+    }
+
+    def vec[A](elems: List[A])(op: A => Unit): Unit = {
+      u32(elems.size)
+      for (elem <- elems)
+        op(elem)
+    }
+
+    def opt[A](elemOpt: Option[A])(op: A => Unit): Unit =
+      vec(elemOpt.toList)(op)
+
+    def name(s: String): Unit = {
+      val utf8 = org.scalajs.ir.UTF8String(s)
+      val len = utf8.length
+      u32(len)
+      var i = 0
+      while (i != len) {
+        byte(utf8(i))
+        i += 1
+      }
+    }
+
+    def byteLengthSubSection(f: Buffer => Unit): Unit = {
+      val subBuffer = new Buffer()
+      f(subBuffer)
+      val subResult = subBuffer.result()
+
+      this.u32(subResult.length)
+      this.rawByteArray(subResult)
+    }
+
+    @tailrec
+    private def unsignedLEB128(value: Long): Unit = {
+      val next = value >>> 7
+      if (next == 0) {
+        buf.write(value.toInt)
+      } else {
+        buf.write((value.toInt & 0x7f) | 0x80)
+        unsignedLEB128(next)
+      }
+    }
+
+    @tailrec
+    private def signedLEB128(value: Long): Unit = {
+      val chunk = value.toInt & 0x7f
+      val next = value >> 7
+      if (next == (if ((chunk & 0x40) != 0) -1 else 0)) {
+        buf.write(chunk)
+      } else {
+        buf.write(chunk | 0x80)
+        signedLEB128(next)
+      }
+    }
+  }
+}

--- a/wasm/src/main/scala/converters/WasmTextWriter.scala
+++ b/wasm/src/main/scala/converters/WasmTextWriter.scala
@@ -209,6 +209,12 @@ class WasmTextWriter {
     }
     b.newLine()
     b.appendElement(instr.mnemonic)
+    instr match {
+      case instr: StructuredLabeledInstr =>
+        instr.label.foreach(writeImmediate(_, instr))
+      case _ =>
+        ()
+    }
     instr.immediates.foreach { i => writeImmediate(i, instr) }
     instr match {
       case _: BLOCK | _: LOOP | _: IF | ELSE | _: CATCH | _: TRY => b.indent()

--- a/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
@@ -442,7 +442,7 @@ class WasmExpressionBuilder(ctx: FunctionTypeWriterWasmContext, fctx: WasmFuncti
     cond ++
       List(
         IF(BlockType.ValueType(ty)),
-        LOOP(label)
+        LOOP(BlockType.ValueType(ty), Some(label))
       ) ++ transformTree(t.body) ++ cond ++
       List(
         BR_IF(label),
@@ -453,7 +453,7 @@ class WasmExpressionBuilder(ctx: FunctionTypeWriterWasmContext, fctx: WasmFuncti
 
   private def transformBlock(t: IRTrees.Block): List[WasmInstr] = {
     val ty = TypeTransformer.transformType(t.tpe)(ctx)
-    BLOCK(BlockType.ValueType(ty)) +:
+    BLOCK(BlockType.ValueType(ty), None) +:
       t.stats.flatMap(transformTree) :+
       END
   }

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -176,11 +176,19 @@ object WasmInstr {
 
   // Control instructions
   // https://webassembly.github.io/spec/core/syntax/instructions.html#control-instructions
+  sealed abstract class StructuredLabeledInstr(
+    mnemonic: String,
+    opcode: Int,
+    immediates: List[WasmImmediate]
+  ) extends WasmInstr(mnemonic, opcode, immediates) {
+    val label: Option[LabelIdx]
+  }
+
   case object UNREACHABLE extends WasmInstr("unreachable", 0x00)
   case object NOP extends WasmInstr("nop", 0x01)
-  case class BLOCK(i: BlockType) extends WasmInstr("block", 0x02, List(i))
-  case class LOOP(i: LabelIdx) extends WasmInstr("loop", 0x03, List(i))
-  case class IF(i: BlockType) extends WasmInstr("if", 0x04, List(i))
+  case class BLOCK(i: BlockType, label: Option[LabelIdx]) extends StructuredLabeledInstr("block", 0x02, List(i))
+  case class LOOP(i: BlockType, label: Option[LabelIdx]) extends StructuredLabeledInstr("loop", 0x03, List(i))
+  case class IF(i: BlockType, label: Option[LabelIdx] = None) extends StructuredLabeledInstr("if", 0x04, List(i))
   case object ELSE extends WasmInstr("else", 0x05)
   case object END extends WasmInstr("end", 0x0b)
   case class BR(i: LabelIdx) extends WasmInstr("br", 0x0c, List(i))
@@ -263,7 +271,7 @@ object WasmInstr {
 
   case class ARRAY_NEW(i: TypeIdx) extends WasmInstr("array.new", 0xfb_06, List(i))
   case class ARRAY_NEW_DEFAULT(i: TypeIdx) extends WasmInstr("array.new_default", 0xfb_07, List(i))
-  case class ARRAY_NEW_FIXED(i: TypeIdx, size: I32) extends WasmInstr("array.new_fixed", 0xfb_07, List(i, size))
+  case class ARRAY_NEW_FIXED(i: TypeIdx, size: I32) extends WasmInstr("array.new_fixed", 0xfb_08, List(i, size))
   case class ARRAY_GET(i: TypeIdx) extends WasmInstr("array.get", 0xfb_0b, List(i))
   case class ARRAY_GET_S(i: TypeIdx) extends WasmInstr("array.get_s", 0xfb_0c, List(i))
   case class ARRAY_GET_U(i: TypeIdx) extends WasmInstr("array.get_u", 0xfb_0d, List(i))

--- a/wasm/src/main/scala/wasm4s/Types.scala
+++ b/wasm/src/main/scala/wasm4s/Types.scala
@@ -17,27 +17,27 @@ object Types {
 
   // case object WasmTypeNone extends WasmType
   case object WasmUnreachableType extends WasmType("unreachable", -0x40)
-  case object WasmInt32 extends WasmType("i32", -0x1)
-  case object WasmInt64 extends WasmType("i64", -0x2)
-  case object WasmFloat32 extends WasmType("f32", -0x3)
-  case object WasmFloat64 extends WasmType("f64", -0x4)
+  case object WasmInt32 extends WasmType("i32", 0x7F)
+  case object WasmInt64 extends WasmType("i64", 0x7E)
+  case object WasmFloat32 extends WasmType("f32", 0x7D)
+  case object WasmFloat64 extends WasmType("f64", 0x7C)
   // case object WasmVec128 extends WasmType("v128", -0x5)
   // case object WasmInt8 extends WasmType("i8", -0x6)
   // case object WasmInt16 extends WasmType("i16", -0x7)
 
   // shorthands
   // https://github.com/WebAssembly/gc/blob/main/proposals/gc/MVP.md#reference-types-1
-  case object WasmFuncRef extends WasmType("funcref", -0x10)
-  case object WasmExternRef extends WasmType("externref", -0x11)
+  case object WasmFuncRef extends WasmType("funcref", 0x70)
+  case object WasmExternRef extends WasmType("externref", 0x6F)
   /** shorthand for (ref null any) */
-  case object WasmAnyRef extends WasmType("anyref", -0x12)
-  case object WasmEqRef extends WasmType("eqref", -0x13)
+  case object WasmAnyRef extends WasmType("anyref", 0x6E)
+  case object WasmEqRef extends WasmType("eqref", 0x6D)
   case object WasmRefNullrefType extends WasmType("nullref", -0x0F) // Shorthand for (ref null none)
   case object WasmRefNullExternrefType extends WasmType("nullexternref", -0x0E) // Shorthand for (ref null noextern)
-  case class WasmRefNullType(val heapType: WasmHeapType) extends WasmType("ref null", -0x14) {
+  case class WasmRefNullType(val heapType: WasmHeapType) extends WasmType("ref null", 0x63) {
     override def show: String = s"(ref null ${heapType.show})"
   }
-  case class WasmRefType(val heapType: WasmHeapType) extends WasmType("ref", -0x15) {
+  case class WasmRefType(val heapType: WasmHeapType) extends WasmType("ref", 0x64) {
     override def show: String = s"(ref ${heapType.show})"
   }
 
@@ -55,14 +55,14 @@ object Types {
         override def show: String = name
     }
     object Simple {
-      object Func extends Simple("func", -0x10)
-      object Extern extends Simple("extern", -0x11)
-      object Any extends Simple("any", -0x12)
-      object Eq extends Simple("eq", -0x13)
-      object Array extends Simple("array", -0x14)
-      object Struct extends Simple("struct", -0x15)
-      object None extends Simple("none", -0x0f)
-      object NoExtern extends Simple("noextern", -0x0e)
+      object Func extends Simple("func", 0x70)
+      object Extern extends Simple("extern", 0x6F)
+      object Any extends Simple("any", 0x6E)
+      object Eq extends Simple("eq", 0x6D)
+      object Array extends Simple("array", 0x6A)
+      object Struct extends Simple("struct", 0x6B)
+      object None extends Simple("none", 0x71)
+      object NoExtern extends Simple("noextern", 0x72)
     }
 
     val ObjectType = Type(WasmStructTypeName(IRNames.ObjectClass))


### PR DESCRIPTION
This way, for the normal development flow, we do not even need the reference interpreter, and hence no Docker. We only need `deno` to be installed.

This commit includes fixing the opcodes of a number of nodes.