### PR TITLE
Implement enough things to enable the hijacked class companions.

### DIFF
--- a/wasm/src/main/scala/Compiler.scala
+++ b/wasm/src/main/scala/Compiler.scala
@@ -1,10 +1,7 @@
 package wasm
 
+import wasm.ir2wasm._
 import wasm.wasm4s._
-import wasm.ir2wasm.TypeTransformer
-import wasm.ir2wasm.WasmBuilder
-import wasm.wasm4s.WasmInstr._
-import wasm.utils.TestIRBuilder._
 
 import org.scalajs.ir
 import org.scalajs.ir.Trees._
@@ -21,8 +18,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 import scala.scalajs.js.typedarray._
-
-import _root_.ir2wasm.Preprocessor
 
 object Compiler {
   def compileIRFiles(irFiles: Seq[IRFile])(implicit ec: ExecutionContext): Future[Unit] = {

--- a/wasm/src/main/scala/ir2wasm/LibraryPatches.scala
+++ b/wasm/src/main/scala/ir2wasm/LibraryPatches.scala
@@ -1,0 +1,111 @@
+package wasm.ir2wasm
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import org.scalajs.ir.ClassKind._
+import org.scalajs.ir.Names._
+import org.scalajs.ir.Position
+import org.scalajs.ir.Trees._
+import org.scalajs.ir.Types._
+
+import org.scalajs.linker.interface.IRFile
+import org.scalajs.linker.interface.unstable.IRFileImpl
+
+import wasm.utils.TestIRBuilder._
+import wasm.utils.MemClassDefIRFile
+
+/** Patches that we apply to the standard library classes to make them wasm-friendly. */
+object LibraryPatches {
+  def patchIRFiles(irFiles: Seq[IRFile])(implicit ec: ExecutionContext): Future[Seq[IRFile]] = {
+    val patched1: Future[Seq[IRFile]] = Future.traverse(irFiles) { irFile =>
+      val irFileImpl = IRFileImpl.fromIRFile(irFile)
+      irFileImpl.entryPointsInfo.flatMap { entryPointsInfo =>
+        MethodPatches.get(entryPointsInfo.className) match {
+          case None =>
+            Future.successful(irFile)
+          case Some(patches) =>
+            irFileImpl.tree.map(classDef => MemClassDefIRFile(applyMethodPatches(classDef, patches)))
+        }
+      }
+    }
+
+    patched1.map(FloatingPointBitsIRFile +: _)
+  }
+
+  private val FloatingPointBitsIRFile: IRFile = {
+    val classDef = ClassDef(
+      ClassIdent("java.lang.FloatingPointBits$"),
+      NON,
+      ModuleClass,
+      None,
+      Some(ClassIdent(ObjectClass)),
+      Nil,
+      None,
+      None,
+      Nil,
+      List(
+        trivialCtor("java.lang.FloatingPointBits$"),
+        MethodDef(
+          EMF, MethodIdent(m("numberHashCode", List(D), I)), NON,
+          List(paramDef("value", DoubleType)), IntType,
+          Some(Block(
+            // TODO This is not a compliant but it's good enough for now
+            UnaryOp(UnaryOp.DoubleToInt, VarRef("value")(DoubleType))
+          ))
+        )(EOH, NOV)
+      ),
+      None,
+      Nil,
+      Nil,
+      Nil
+    )(EOH)
+
+    MemClassDefIRFile(classDef)
+  }
+
+  private val MethodPatches: Map[ClassName, List[MethodDef]] = {
+    Map(
+      BoxedCharacterClass.withSuffix("$") -> List(
+        MethodDef(
+          EMF, m("toString", List(C), T), NON,
+          List(paramDef("c", CharType)), ClassType(BoxedStringClass),
+          Some(BinaryOp(BinaryOp.String_+, StringLiteral(""), VarRef("c")(CharType)))
+        )(EOH, NOV)
+      ),
+
+      BoxedIntegerClass.withSuffix("$") -> List(
+        MethodDef(
+          EMF, m("toHexString", List(I), T), NON,
+          List(paramDef("i", IntType)), ClassType(BoxedStringClass),
+          Some(
+            // TODO Write a compliant implementation
+            BinaryOp(BinaryOp.String_+, StringLiteral(""), VarRef("i")(IntType))
+          )
+        )(EOH, NOV)
+      )
+    )
+  }
+
+  private def applyMethodPatches(classDef: ClassDef, patches: List[MethodDef]): ClassDef = {
+    val patchesMap = patches.map(m => m.name.name -> m).toMap
+    val patchedMethods = classDef.methods.map(m => patchesMap.getOrElse(m.name.name, m))
+
+    import classDef._
+    ClassDef(
+      name,
+      originalName,
+      kind,
+      jsClassCaptures,
+      superClass,
+      interfaces,
+      jsSuperClass,
+      jsNativeLoadSpec,
+      fields,
+      patchedMethods,
+      jsConstructor,
+      jsMethodProps,
+      jsNativeMembers,
+      topLevelExportDefs
+    )(EOH)(pos)
+  }
+}

--- a/wasm/src/main/scala/ir2wasm/Preprocessor.scala
+++ b/wasm/src/main/scala/ir2wasm/Preprocessor.scala
@@ -1,4 +1,4 @@
-package ir2wasm
+package wasm.ir2wasm
 
 import wasm.wasm4s._
 

--- a/wasm/src/main/scala/utils/TestIRBuilder.scala
+++ b/wasm/src/main/scala/utils/TestIRBuilder.scala
@@ -30,7 +30,11 @@ object TestIRBuilder {
   val JSCtorFlags = EMF.withNamespace(MemberNamespace.Public)
 
   val V = VoidRef
+  val C = CharRef
   val I = IntRef
+  val J = LongRef
+  val F = FloatRef
+  val D = DoubleRef
   val Z = BooleanRef
   val O = ClassRef(ObjectClass)
   val T = ClassRef(BoxedStringClass)

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -64,6 +64,8 @@ object WasmInstr {
   case object I64_EXTEND8_S extends WasmInstr("i64.extend8_s", 0xc2)
   case object I64_EXTEND16_S extends WasmInstr("i64.extend16_s", 0xc3)
   case object I64_EXTEND32_S extends WasmInstr("i64.extend32_s", 0xc4)
+  case object I32_TRUNC_SAT_F64_S extends WasmInstr("i32.trunc_sat_f64_s", 0xfc_02)
+  case object I64_TRUNC_SAT_F64_S extends WasmInstr("i64.trunc_sat_f64_s", 0xfc_06)
 
   // Binary operations
   case object I32_EQ extends WasmInstr("i32.eq", 0x46)


### PR DESCRIPTION
After this PR, we only have the hijacked classes themselves and `java.lang.Class` in the exclude list.