### PR TITLE
Setup a testing infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,19 @@ $ deno run --allow-read run.mjs
 - The WasmGC reference interpreter can be used to validate and convert between the binary and text form:
   - https://github.com/WebAssembly/gc/tree/main/interpreter
   - Use docker image for it https://github.com/tanishiking/wasmgc-docker
+
+### Testing
+
+Requires NodeJS >= 22 (for enough support of WasmGC).
+
+```sh
+$ NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly nvm install v22
+```
+
+- `tests/test` will
+  - Run `testSuite/run` to compile the Scala code under `test-suite` to WebAssembly
+  - Run the WebAssembly binary using NodeJS
+- Each Scala program in `test-suite` should have a function that has no arguments and return a Boolean value. The test passes if the function returns `true`.
+- When you add a test, 
+  - Add a file under `test-suite`
+  - Add a test case to `cli/src/main/scala/TestSuites.scala` (`methodName` should be a exported function name).

--- a/cli/src/main/scala/Main.scala
+++ b/cli/src/main/scala/Main.scala
@@ -2,35 +2,68 @@ package cli
 
 import scala.scalajs.js
 
-import scala.concurrent.ExecutionContext
 import wasm.Compiler
 
+import org.scalajs.linker.interface.ModuleInitializer
+import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits._
+
+import scala.concurrent.Future
+
 object Main {
-  private implicit val ec: ExecutionContext = ExecutionContext.global
   def main(args: Array[String]): Unit = {
     val modeEnvVar = js.Dynamic.global.process.env.SCALAJS_MODE
-
     val cpEnvVar = js.Dynamic.global.process.env.SCALAJS_CLASSPATH
+
     val classpath = (cpEnvVar: Any) match {
       case cpEnvVar: String if cpEnvVar != "" =>
         cpEnvVar.split(';').toList
       case _ =>
         throw new IllegalArgumentException("The classpath was not provided.")
     }
-    println(classpath)
 
-    val result = for {
-      irFiles <- new CliReader(classpath).irFiles
-      _ <- Compiler.compileIRFiles(irFiles)
-    } yield {
-      println("Module successfully initialized")
-      ()
+    val mode = (modeEnvVar: Any) match {
+      case modeEnvVar if modeEnvVar == "testsuite" => "testsuite"
+      case _                                       => "compile"
     }
+
+    val result =
+      if (mode == "testsuite") {
+        val className = TestSuites.suites.map(_.className)
+        val moduleInitializers = className
+          .map { clazz =>
+            ModuleInitializer.mainMethod(clazz, "main")
+          }
+          .zip(className)
+
+        for {
+          irFiles <- new CliReader(classpath).irFiles
+          _ <- Future.sequence {
+            moduleInitializers.map { case (moduleInitializer, className) =>
+              Compiler.compileIRFiles(
+                irFiles,
+                List(moduleInitializer),
+                s"$className"
+              )
+            }
+          }
+        } yield {
+          println("Module successfully initialized")
+          ()
+        }
+      } else {
+        for {
+          irFiles <- new CliReader(classpath).irFiles
+          _ <- Compiler.compileIRFiles(irFiles, Nil, s"output")
+        } yield {
+          println("Module successfully initialized")
+          ()
+        }
+      }
+
     result.recover { case th: Throwable =>
       System.err.println("Module initialization failed:")
       th.printStackTrace()
       js.Dynamic.global.process.exit(1)
     }
-
   }
 }

--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -1,0 +1,9 @@
+package cli
+
+object TestSuites {
+  case class TestSuite(className: String, methodName: String)
+  val suites = List(
+    TestSuite("testsuite.core.simple.Simple", "simple"),
+    TestSuite("testsuite.core.add.Add", "add")
+  )
+}

--- a/test-suite/src/main/scala/testsuite/core/Add.scala
+++ b/test-suite/src/main/scala/testsuite/core/Add.scala
@@ -1,0 +1,11 @@
+package testsuite.core.add
+
+import scala.scalajs.js.annotation._
+
+object Add {
+  def main(): Unit = { val _ = test() }
+  @JSExportTopLevel("add")
+  def test(): Boolean = {
+    1 + 1 == 2
+  }
+}

--- a/test-suite/src/main/scala/testsuite/core/Simple.scala
+++ b/test-suite/src/main/scala/testsuite/core/Simple.scala
@@ -1,0 +1,11 @@
+package testsuite.core.simple
+
+import scala.scalajs.js.annotation._
+
+object Simple {
+  def main(): Unit = { val _ = test() }
+  @JSExportTopLevel("simple")
+  def test(): Boolean = {
+    true
+  }
+}

--- a/tests/src/test/scala/tests/CoreTests.scala
+++ b/tests/src/test/scala/tests/CoreTests.scala
@@ -1,0 +1,30 @@
+package tests
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits._
+
+class CoreTests extends munit.FunSuite {
+  cli.TestSuites.suites.map { suite =>
+    test(suite.className) {
+      val file = s"./target/${suite.className}.wasm"
+      val wasmBuffer = FS.readFileSync(file)
+      val wasmModule =
+        js.Dynamic.global.WebAssembly.instantiate(wasmBuffer).asInstanceOf[js.Promise[js.Dynamic]]
+      wasmModule.toFuture.map { module =>
+        val testFunction =
+          module.instance.exports
+            .asInstanceOf[js.Dynamic]
+            .selectDynamic(suite.methodName)
+            .asInstanceOf[js.Function0[Int]]
+        assert(testFunction() == 1)
+      }
+    }
+  }
+
+}
+
+private object FS {
+  @js.native @JSImport("fs")
+  def readFileSync(file: String): js.typedarray.Uint8Array = js.native
+}

--- a/tests/src/test/scala/tests/CoreTests.scala
+++ b/tests/src/test/scala/tests/CoreTests.scala
@@ -14,7 +14,6 @@ class CoreTests extends munit.FunSuite {
       wasmModule.toFuture.map { module =>
         val testFunction =
           module.instance.exports
-            .asInstanceOf[js.Dynamic]
             .selectDynamic(suite.methodName)
             .asInstanceOf[js.Function0[Int]]
         assert(testFunction() == 1)

--- a/wasm/src/main/scala/Compiler.scala
+++ b/wasm/src/main/scala/Compiler.scala
@@ -23,10 +23,8 @@ object Compiler {
   def compileIRFiles(
       irFiles: Seq[IRFile],
       moduleInitializers: List[ModuleInitializer],
-      // outputDir: String,
       outputName: String
   )(implicit ec: ExecutionContext): Future[Unit] = {
-
     val module = new WasmModule
     val builder = new WasmBuilder()
     implicit val context: WasmContext = new WasmContext(module)

--- a/wasm/src/main/scala/ir2wasm/TypeTransformer.scala
+++ b/wasm/src/main/scala/ir2wasm/TypeTransformer.scala
@@ -35,8 +35,9 @@ object TypeTransformer {
       t: IRTypes.Type
   )(implicit ctx: ReadOnlyWasmContext): List[Types.WasmType] =
     t match {
-      case IRTypes.NoType => Nil
-      case _              => List(transformType(t))
+      case IRTypes.NoType                                                      => Nil
+      case IRTypes.ClassType(className) if className == IRNames.BoxedUnitClass => Nil
+      case _ => List(transformType(t))
     }
   def transformType(t: IRTypes.Type)(implicit ctx: ReadOnlyWasmContext): Types.WasmType =
     t match {

--- a/wasm/src/test/scala/MySuite.scala
+++ b/wasm/src/test/scala/MySuite.scala
@@ -1,9 +1,0 @@
-// For more information on writing tests, see
-// https://scalameta.org/munit/docs/getting-started.html
-class MySuite extends munit.FunSuite {
-  test("example test that succeeds") {
-    val obtained = 42
-    val expected = 42
-    assertEquals(obtained, expected)
-  }
-}


### PR DESCRIPTION
Requires NodeJS >= 22 (for enough support of WasmGC).

With nvm, you can install the nightly version of Node with the following command. (but Node 22 should become a "current" version in April or May 2024).

```sh
$ NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly nvm install v22
```

- `tests/test` will
  - Run `testSuite/run` to compile the Scala code under `test-suite` to WebAssembly
  - Run the WebAssembly binary using NodeJS
- Each Scala program in `test-suite` should have a function that has no arguments and return a Boolean value. The test passes if the function returns `true`.
- When you add a test,
  - Add a file under `test-suite`
  - Add a test case to `cli/src/main/scala/TestSuites.scala` (`methodName` should be a exported function name).