### PR TITLE
Support transformation of hijacked classes.

### DIFF
--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -4,6 +4,7 @@ object TestSuites {
   case class TestSuite(className: String, methodName: String)
   val suites = List(
     TestSuite("testsuite.core.simple.Simple", "simple"),
-    TestSuite("testsuite.core.add.Add", "add")
+    TestSuite("testsuite.core.add.Add", "add"),
+    TestSuite("testsuite.core.asinstanceof.AsInstanceOfTest", "asInstanceOf")
   )
 }

--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -5,6 +5,7 @@ object TestSuites {
   val suites = List(
     TestSuite("testsuite.core.simple.Simple", "simple"),
     TestSuite("testsuite.core.add.Add", "add"),
-    TestSuite("testsuite.core.asinstanceof.AsInstanceOfTest", "asInstanceOf")
+    TestSuite("testsuite.core.asinstanceof.AsInstanceOfTest", "asInstanceOf"),
+    TestSuite("testsuite.core.hijackedclassesmono.HijackedClassesMonoTest", "hijackedClassesMono")
   )
 }

--- a/test-suite/src/main/scala/testsuite/core/AsInstanceOfTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/AsInstanceOfTest.scala
@@ -8,7 +8,8 @@ object AsInstanceOfTest {
   @JSExportTopLevel("asInstanceOf")
   def test(): Boolean = {
     testInt(5) &&
-      testClasses(new Child())
+      testClasses(new Child()) &&
+      testString("foo", true)
   }
 
   def testClasses(c: Child): Boolean = {
@@ -20,6 +21,12 @@ object AsInstanceOfTest {
   def testInt(x: Int): Boolean = {
     val x1 = x.asInstanceOf[Int]
     x1 == 5
+  }
+
+  def testString(s: String, b: Boolean): Boolean = {
+    val s1 = s.asInstanceOf[String]
+    val s2 = ("" + b).asInstanceOf[String]
+    s1.length() == 3 && s2.length() == 4
   }
 
   class Parent {

--- a/test-suite/src/main/scala/testsuite/core/AsInstanceOfTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/AsInstanceOfTest.scala
@@ -1,0 +1,29 @@
+package testsuite.core.asinstanceof
+
+import scala.scalajs.js.annotation._
+
+object AsInstanceOfTest {
+  def main(): Unit = { val _ = test() }
+
+  @JSExportTopLevel("asInstanceOf")
+  def test(): Boolean = {
+    testInt(5) &&
+      testClasses(new Child())
+  }
+
+  def testClasses(c: Child): Boolean = {
+    val c1 = c.asInstanceOf[Child]
+    val c2 = c.asInstanceOf[Parent]
+    c1.foo() == 5 && c2.foo() == 5
+  }
+
+  def testInt(x: Int): Boolean = {
+    val x1 = x.asInstanceOf[Int]
+    x1 == 5
+  }
+
+  class Parent {
+    def foo(): Int = 5
+  }
+  class Child extends Parent
+}

--- a/test-suite/src/main/scala/testsuite/core/HijackedClassesMonoTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/HijackedClassesMonoTest.scala
@@ -1,0 +1,22 @@
+package testsuite.core.hijackedclassesmono
+
+import scala.scalajs.js.annotation._
+
+object HijackedClassesMonoTest {
+  def main(): Unit = { val _ = test() }
+
+  @JSExportTopLevel("hijackedClassesMono")
+  def test(): Boolean = {
+    testInteger(5) &&
+      testString("foo")
+  }
+
+  def testInteger(x: Int): Boolean = {
+    x.hashCode() == 5
+  }
+
+  def testString(foo: String): Boolean = {
+    foo.length() == 3 &&
+      foo.hashCode() == 101574
+  }
+}

--- a/wasm/src/main/scala/Compiler.scala
+++ b/wasm/src/main/scala/Compiler.scala
@@ -73,10 +73,9 @@ object Compiler {
 
   private val ExcludedClasses: Set[ir.Names.ClassName] = {
     import ir.Names._
-    HijackedClasses ++ // hijacked classes
-      Set(
-        ClassClass // java.lang.Class
-      )
+    Set(
+      ClassClass // java.lang.Class
+    )
   }
 
   private def showLinkedClass(clazz: LinkedClass): Unit = {

--- a/wasm/src/main/scala/ir2wasm/LibraryPatches.scala
+++ b/wasm/src/main/scala/ir2wasm/LibraryPatches.scala
@@ -65,6 +65,15 @@ object LibraryPatches {
 
   private val MethodPatches: Map[ClassName, List[MethodDef]] = {
     Map(
+      ObjectClass -> List(
+        // TODO Remove this patch when we support getClass() and full string concatenation
+        MethodDef(
+          EMF, m("toString", Nil, T), NON,
+          Nil, ClassType(BoxedStringClass),
+          Some(StringLiteral("[object]"))
+        )(EOH, NOV)
+      ),
+
       BoxedCharacterClass.withSuffix("$") -> List(
         MethodDef(
           EMF, m("toString", List(C), T), NON,

--- a/wasm/src/main/scala/ir2wasm/Preprocessor.scala
+++ b/wasm/src/main/scala/ir2wasm/Preprocessor.scala
@@ -25,10 +25,10 @@ object Preprocessor {
 
   private def preprocess(clazz: LinkedClass)(implicit ctx: WasmContext): Unit = {
     clazz.kind match {
-      case ClassKind.ModuleClass | ClassKind.Class | ClassKind.Interface =>
+      case ClassKind.ModuleClass | ClassKind.Class | ClassKind.Interface | ClassKind.HijackedClass =>
         collectMethods(clazz)
       case ClassKind.JSClass | ClassKind.JSModuleClass | ClassKind.NativeJSModuleClass |
-          ClassKind.AbstractJSType | ClassKind.NativeJSClass | ClassKind.HijackedClass =>
+          ClassKind.AbstractJSType | ClassKind.NativeJSClass =>
         ???
     }
   }

--- a/wasm/src/main/scala/ir2wasm/Preprocessor.scala
+++ b/wasm/src/main/scala/ir2wasm/Preprocessor.scala
@@ -48,7 +48,8 @@ object Preprocessor {
         infos,
         clazz.fields.collect { case f: IRTrees.FieldDef => Names.WasmFieldName(f.name.name) },
         clazz.superClass.map(_.name),
-        clazz.interfaces.map(_.name)
+        clazz.interfaces.map(_.name),
+        clazz.ancestors
       )
     )
   }

--- a/wasm/src/main/scala/ir2wasm/Preprocessor.scala
+++ b/wasm/src/main/scala/ir2wasm/Preprocessor.scala
@@ -17,10 +17,8 @@ object Preprocessor {
     for (clazz <- classes)
       preprocess(clazz)
 
-    for (clazz <- classes) {
-      if (clazz.className != IRNames.ObjectClass)
-        collectAbstractMethodCalls(clazz)
-    }
+    for (clazz <- classes)
+      collectAbstractMethodCalls(clazz)
   }
 
   private def preprocess(clazz: LinkedClass)(implicit ctx: WasmContext): Unit = {
@@ -34,12 +32,9 @@ object Preprocessor {
   }
 
   private def collectMethods(clazz: LinkedClass)(implicit ctx: WasmContext): Unit = {
-    val infos =
-      if (clazz.name.name == IRNames.ObjectClass) Nil
-      else
-        clazz.methods.filterNot(_.flags.namespace.isConstructor).map { method =>
-          makeWasmFunctionInfo(clazz, method)
-        }
+    val infos = clazz.methods.filterNot(_.flags.namespace.isConstructor).map { method =>
+      makeWasmFunctionInfo(clazz, method)
+    }
     ctx.putClassInfo(
       clazz.name.name,
       new WasmClassInfo(

--- a/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
@@ -69,15 +69,10 @@ class WasmBuilder {
     )
     ctx.addGCType(structType)
 
-    // Do not generate methods in Object for now
-    if (clazz.name.name == IRNames.ObjectClass)
-      clazz.methods.filter(_.name.name == IRNames.NoArgConstructorName).foreach { method =>
-        genFunction(clazz, method)
-      }
-    else
-      clazz.methods.foreach { method =>
-        genFunction(clazz, method)
-      }
+    // implementation of methods
+    clazz.methods.foreach { method =>
+      genFunction(clazz, method)
+    }
 
     structType
   }

--- a/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
@@ -63,6 +63,7 @@ class WasmExpressionBuilder(ctx: FunctionTypeWriterWasmContext, fctx: WasmFuncti
         transformApplyStatically(t)
       case t: IRTrees.Apply              => transformApply(t)
       case t: IRTrees.ApplyDynamicImport => ???
+      case t: IRTrees.AsInstanceOf       => transformAsInstanceOf(t)
       case t: IRTrees.Block              => transformBlock(t)
       case t: IRTrees.Labeled            => transformLabeled(t)
       case t: IRTrees.Return             => transformReturn(t)
@@ -538,6 +539,24 @@ class WasmExpressionBuilder(ctx: FunctionTypeWriterWasmContext, fctx: WasmFuncti
         ???
     }
   }
+
+  private def transformAsInstanceOf(tree: IRTrees.AsInstanceOf): List[WasmInstr] = {
+    val exprInstrs = transformTree(tree.expr)
+
+    val sourceTpe = tree.expr.tpe
+    val targetTpe = tree.tpe
+
+    if (IRTypes.isSubtype(sourceTpe, targetTpe)(isSubclass(_, _))) {
+      // Common case where no cast is necessary
+      exprInstrs
+    } else {
+      println(tree)
+      ???
+    }
+  }
+
+  private def isSubclass(subClass: IRNames.ClassName, superClass: IRNames.ClassName): Boolean =
+    ctx.getClassInfo(subClass).ancestors.contains(superClass)
 
   private def transformVarRef(r: IRTrees.VarRef): LOCAL_GET = {
     val name = WasmLocalName.fromIR(r.ident.name)

--- a/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
@@ -402,6 +402,17 @@ class WasmExpressionBuilder(ctx: FunctionTypeWriterWasmContext, fctx: WasmFuncti
       case BinaryOp.Long_>>> => longShiftOp(I64_SHR_U)
       case BinaryOp.Long_>>  => longShiftOp(I64_SHR_S)
 
+      // New in 1.11
+      case BinaryOp.String_charAt =>
+        transformTree(binary.lhs) ++ // push the string
+          List(
+            STRUCT_GET(TypeIdx(WasmStructTypeName.string), StructFieldIdx(0)), // get the array
+          ) ++
+          transformTree(binary.rhs) ++ // push the index
+          List(
+            ARRAY_GET_U(TypeIdx(WasmArrayTypeName.stringData)) // access the element of the array
+          )
+
       case _ => transformElementaryBinaryOp(binary)
     }
   }
@@ -480,9 +491,6 @@ class WasmExpressionBuilder(ctx: FunctionTypeWriterWasmContext, fctx: WasmFuncti
       case BinaryOp.Double_<= => F64_LE
       case BinaryOp.Double_>  => F64_GT
       case BinaryOp.Double_>= => F64_GE
-
-      // // New in 1.11
-      case BinaryOp.String_charAt => ??? // TODO
     }
     lhsInstrs ++ rhsInstrs :+ operation
   }

--- a/wasm/src/main/scala/wasm4s/WasmContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmContext.scala
@@ -129,7 +129,8 @@ object WasmContext {
       private var _methods: List[WasmFunctionInfo],
       private val fields: List[WasmFieldName],
       val superClass: Option[IRNames.ClassName],
-      val interfaces: List[IRNames.ClassName]
+      val interfaces: List[IRNames.ClassName],
+      val ancestors: List[IRNames.ClassName]
   ) {
 
     def isInterface = kind == ClassKind.Interface

--- a/wasm/src/main/scala/wasm4s/WasmContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmContext.scala
@@ -146,6 +146,12 @@ object WasmContext {
       }
     }
 
+    def getMethodInfo(methodName: IRNames.MethodName): WasmFunctionInfo = {
+      methods.find(_.name.methodName == methodName.nameString).getOrElse {
+        throw new IllegalArgumentException(s"Cannot find method ${methodName.nameString} in class ${name.nameString}")
+      }
+    }
+
     def getFieldIdx(name: WasmFieldName): WasmImmediate.StructFieldIdx =
       fields.indexWhere(_ == name) match {
         case i if i < 0 => throw new Error(s"Field not found: $name")


### PR DESCRIPTION
This removes the last remaining exclude filters we had, including on the list of methods of `j.l.Object`.