### PR TITLE
fix: Add tests for virtual dispatch + fix bug for abstract class

### DIFF
--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -5,6 +5,8 @@ object TestSuites {
   val suites = List(
     TestSuite("testsuite.core.simple.Simple", "simple"),
     TestSuite("testsuite.core.add.Add", "add"),
+    TestSuite("testsuite.core.add.Add", "add"),
+    TestSuite("testsuite.core.virtualdispatch.VirtualDispatch", "virtualDispatch"),
     TestSuite("testsuite.core.asinstanceof.AsInstanceOfTest", "asInstanceOf"),
     TestSuite("testsuite.core.hijackedclassesmono.HijackedClassesMonoTest", "hijackedClassesMono")
   )

--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -7,6 +7,7 @@ object TestSuites {
     TestSuite("testsuite.core.add.Add", "add"),
     TestSuite("testsuite.core.add.Add", "add"),
     TestSuite("testsuite.core.virtualdispatch.VirtualDispatch", "virtualDispatch"),
+    TestSuite("testsuite.core.interfacecall.InterfaceCall", "interfaceCall"),
     TestSuite("testsuite.core.asinstanceof.AsInstanceOfTest", "asInstanceOf"),
     TestSuite("testsuite.core.hijackedclassesmono.HijackedClassesMonoTest", "hijackedClassesMono")
   )

--- a/test-suite/src/main/scala/testsuite/core/InterfaceCall.scala
+++ b/test-suite/src/main/scala/testsuite/core/InterfaceCall.scala
@@ -1,0 +1,31 @@
+package testsuite.core.interfacecall
+
+import scala.scalajs.js.annotation._
+
+object InterfaceCall {
+  def main(): Unit = { val _ = test() }
+
+  @JSExportTopLevel("interfaceCall")
+  def test(): Boolean = {
+    val c = new Concrete()
+    c.plus(c.zero, 1) == 1 && c.minus(1, c.zero) == 1
+  }
+
+  class Concrete extends AddSub with Zero {
+    override def zero: Int = 0
+  }
+
+  trait Adder {
+    def plus(a: Int, b: Int) = a + b
+  }
+
+  trait Sub {
+    def minus(a: Int, b: Int): Int = a - b
+  }
+
+  trait AddSub extends Adder with Sub
+
+  trait Zero {
+    def zero: Int
+  }
+}

--- a/test-suite/src/main/scala/testsuite/core/VirtualDispatch.scala
+++ b/test-suite/src/main/scala/testsuite/core/VirtualDispatch.scala
@@ -1,0 +1,54 @@
+package testsuite.core.virtualdispatch
+
+import scala.scalajs.js.annotation._
+
+object VirtualDispatch {
+  def main(): Unit = { val _ = test() }
+
+  @JSExportTopLevel("virtualDispatch")
+  def test(): Boolean = {
+    val a = new A
+    val b = new B
+
+    testA(a) &&
+    testB(a, isInstanceOfA = true) &&
+    testB(b, isInstanceOfA = false) &&
+    testC(a, isInstanceOfA = true) &&
+    testC(b, isInstanceOfA = false)
+  }
+
+  def testA(a: A): Boolean = {
+    a.a == 2 && a.impl == 2 && a.b == 1 && a.c == 1
+  }
+
+  def testB(b: B, isInstanceOfA: Boolean): Boolean = {
+    if (isInstanceOfA) {
+      b.b == 1 && b.c == 1 && b.impl == 2
+    } else {
+      b.b == 1 && b.c == 1 && b.impl == 0
+    }
+  }
+
+  def testC(c: C, isInstanceOfA: Boolean): Boolean = {
+    if (isInstanceOfA) {
+      c.c == 1 && c.impl == 2
+    } else {
+      c.c == 1 && c.impl == 0
+    }
+  }
+
+  class A extends B {
+    def a: Int = 2
+    override def impl = 2
+  }
+
+  class B extends C {
+    def b: Int = 1
+    override def c: Int = 1
+  }
+
+  abstract class C {
+    def c: Int
+    def impl: Int = 0
+  }
+}

--- a/wasm/src/main/scala/wasm4s/Names.scala
+++ b/wasm/src/main/scala/wasm4s/Names.scala
@@ -156,7 +156,7 @@ object Names {
     final case class WasmVTableTypeName private (override private[wasm4s] val name: String)
         extends WasmTypeName(name)
     object WasmVTableTypeName {
-      def fromIR(ir: IRNames.ClassName) = new WasmVTableTypeName(ir.nameString)
+      def apply(ir: IRNames.ClassName) = new WasmVTableTypeName(ir.nameString)
     }
 
     final case class WasmITableTypeName private (override private[wasm4s] val name: String)

--- a/wasm/src/main/scala/wasm4s/Wasm.scala
+++ b/wasm/src/main/scala/wasm4s/Wasm.scala
@@ -76,7 +76,11 @@ object WasmStructType {
   val string: WasmStructType = WasmStructType(
     WasmTypeName.WasmStructTypeName.string,
     List(
-      WasmStructField(WasmFieldName.stringData, WasmRefType(WasmHeapType.Type(WasmArrayTypeName.stringData)), false)
+      WasmStructField(
+        WasmFieldName.stringData,
+        WasmRefType(WasmHeapType.Type(WasmArrayTypeName.stringData)),
+        false
+      )
     ),
     None
   )
@@ -93,6 +97,7 @@ case class WasmArrayType(
     field: WasmStructField
 ) extends WasmGCTypeDefinition
 object WasmArrayType {
+
   /** array (ref struct) */
   val itables = WasmArrayType(
     WasmArrayTypeName.itables,
@@ -112,11 +117,11 @@ case class WasmStructField(
     isMutable: Boolean
 )
 object WasmStructField {
-    val itables = WasmStructField(
-        WasmFieldName.itables,
-        WasmRefNullType(WasmHeapType.Type(WasmArrayType.itables.name)),
-        isMutable = false
-    )
+  val itables = WasmStructField(
+    WasmFieldName.itables,
+    WasmRefNullType(WasmHeapType.Type(WasmArrayType.itables.name)),
+    isMutable = false
+  )
 }
 
 /** @see

--- a/wasm/src/main/scala/wasm4s/WasmContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmContext.scala
@@ -37,25 +37,53 @@ trait ReadOnlyWasmContext {
       IRTypes.ArrayType(typeRef)
   }
 
-  def calculateVtable(name: IRNames.ClassName): WasmVTable = {
-    // def collectMethodsFromInterface(iface)
-    def collectMethods(className: IRNames.ClassName): List[WasmFunctionInfo] = {
-      val info = classInfo.getOrElse(className, throw new Error(s"Class not found: $className"))
-      val fromSuperClass = info.superClass.map(collectMethods).getOrElse(Nil)
-      val fromInterfaces = info.interfaces.flatMap(collectMethods)
-      fromSuperClass ++ fromInterfaces ++ info.methods.filterNot(m => m.isAbstract)
-    }
+  /** Collects all methods declared, inherited, and mixed-in by the given class, super-class, and
+    * interfaces.
+    *
+    * @param className
+    *   class to collect methods from
+    * @param includeAbstractMethods
+    *   whether to include abstract methods
+    * @return
+    *   list of methods in order that "collectMethods(superClass) ++ methods from interfaces ++
+    *   methods from the class"
+    */
+  private def collectMethods(
+      className: IRNames.ClassName,
+      includeAbstractMethods: Boolean
+  ): List[WasmFunctionInfo] = {
+    val info = classInfo.getOrElse(className, throw new Error(s"Class not found: $className"))
+    val fromSuperClass =
+      info.superClass.map(collectMethods(_, includeAbstractMethods)).getOrElse(Nil)
+    val fromInterfaces = info.interfaces.flatMap(collectMethods(_, includeAbstractMethods))
+    fromSuperClass ++ fromInterfaces ++
+      (if (includeAbstractMethods) info.methods
+       else info.methods.filterNot(_.isAbstract))
+  }
 
+  private def calculateVtable(
+      name: IRNames.ClassName,
+      includeAbstractMethods: Boolean
+  ): List[WasmFunctionInfo] = {
+    collectMethods(name, includeAbstractMethods)
+      .foldLeft(Array.empty[WasmFunctionInfo]) { case (acc, m) =>
+        acc.indexWhere(_.name.methodName == m.name.methodName) match {
+          case i if i < 0 => acc :+ m
+          case i          => acc.updated(i, m)
+        }
+      }
+      .toList
+  }
+
+  def calculateGlobalVTable(name: IRNames.ClassName): List[WasmFunctionInfo] =
+    // Do not include abstract methods when calculating vtable instance,
+    // all slots should be filled with the function reference to the concrete methods
+    calculateVtable(name, includeAbstractMethods = false)
+
+  def calculateVtableType(name: IRNames.ClassName): WasmVTable = {
     vtablesCache.getOrElseUpdate(
       name, {
-        val functions = collectMethods(name)
-          .foldLeft(Array.empty[WasmFunctionInfo]) { case (acc, m) =>
-            acc.indexWhere(_.name.methodName == m.name.methodName) match {
-              case i if i < 0 => acc :+ m
-              case i          => acc.updated(i, m)
-            }
-          }
-          .toList
+        val functions = calculateVtable(name, includeAbstractMethods = true)
         WasmVTable(functions)
       }
     )
@@ -113,12 +141,16 @@ class WasmContext(val module: WasmModule) extends FunctionTypeWriterWasmContext 
   def putClassInfo(name: IRNames.ClassName, info: WasmClassInfo): Unit =
     classInfo.put(name, info)
 
-  addGlobal(WasmGlobal(
-    WasmGlobalName.WasmUndefName,
-    TypeTransformer.transformType(IRTypes.UndefType)(this),
-    WasmExpr(List(WasmInstr.STRUCT_NEW(WasmImmediate.TypeIdx(WasmTypeName.WasmStructTypeName.undef)))),
-    isMutable = false
-  ))
+  addGlobal(
+    WasmGlobal(
+      WasmGlobalName.WasmUndefName,
+      TypeTransformer.transformType(IRTypes.UndefType)(this),
+      WasmExpr(
+        List(WasmInstr.STRUCT_NEW(WasmImmediate.TypeIdx(WasmTypeName.WasmStructTypeName.undef)))
+      ),
+      isMutable = false
+    )
+  )
 }
 
 object WasmContext {
@@ -148,7 +180,9 @@ object WasmContext {
 
     def getMethodInfo(methodName: IRNames.MethodName): WasmFunctionInfo = {
       methods.find(_.name.methodName == methodName.nameString).getOrElse {
-        throw new IllegalArgumentException(s"Cannot find method ${methodName.nameString} in class ${name.nameString}")
+        throw new IllegalArgumentException(
+          s"Cannot find method ${methodName.nameString} in class ${name.nameString}"
+        )
       }
     }
 
@@ -214,16 +248,5 @@ object WasmContext {
       if (idx < 0) throw new Error(s"Function not found: $name")
       else (idx, functions(idx))
     }
-    def toVTableEntries(vtableTypeName: WasmTypeName): List[WasmInstr] = {
-      functions.map { method =>
-        WasmInstr.REF_FUNC(method.name)
-      } :+ WasmInstr.STRUCT_NEW(vtableTypeName)
-    }
-
   }
-  // object WasmVTable {
-  //   def apply(functions: List[WasmFunctionInfo]): WasmVTable =
-  //       new WasmVTable(functions.map(f => f.name.methodName -> f).toMap)
-  // }
-  // type WasmVTable = List[WasmFunctionInfo]
 }


### PR DESCRIPTION
We had sevelral problems with the vtable implementations

- We'd been generating a global vtable even for an abstract class, but it's not needed because we can't instantiate abstract class
- For calculating the vtable (both it's type and global instance), we filtered out the abstract methods. Therefore, we couldn't resolve a abstract method call from vtable.

For example,

```scala
class A extends B:
  def a = 1

class B extends C:
  def b: Int = 1
  override def c: Int = 1

abstract class C:
  def c: Int
```

The vtable type for C will be an empty table, because there's no concrete methods. Therefore, when we have `x: C`, `x.c` wond't resolve the implementation of `C` because vtable type doesn't have a slot for `c`.

The root cause is that we generated both of the following from one (in-memory) vtable object that doesn't have abstract methods.

- vtable type (for declaring the vtable type, and resolve methods by name at compile time), and
- global vtable instance (for method lookup at runtime)

The former should include abstract methods like `C.c`, and the former should not.