### PR TITLE
Implement monomorphic Array

### DIFF
--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -5,6 +5,7 @@ object TestSuites {
   val suites = List(
     TestSuite("testsuite.core.Simple"),
     TestSuite("testsuite.core.Add"),
+    TestSuite("testsuite.core.ArrayTest"),
     TestSuite("testsuite.core.VirtualDispatch"),
     TestSuite("testsuite.core.InterfaceCall"),
     TestSuite("testsuite.core.AsInstanceOfTest"),

--- a/sample/src/main/scala/Sample.scala
+++ b/sample/src/main/scala/Sample.scala
@@ -5,25 +5,20 @@ import scala.annotation.tailrec
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
-//
-// class Base {
-//   def sqrt(x: Int) = x * x
-// }
-//
 object Main {
   @JSExportTopLevel("test")
   def test(i: Int): Boolean = {
     val loopFib = fib(new LoopFib {}, i)
     val recFib = fib(new RecFib {}, i)
     val tailrecFib = fib(new TailRecFib {}, i)
-    js.Dynamic.global.console.log(s"loopFib: $loopFib -- recFib: $recFib -- tailrecFib: $tailrecFib")
+    js.Dynamic.global.console
+      .log(s"loopFib: $loopFib -- recFib: $recFib -- tailrecFib: $tailrecFib")
     val date = new js.Date(0)
     js.Dynamic.global.console.log(date)
     loopFib == recFib && loopFib == tailrecFib
   }
   def fib(fib: Fib, n: Int): Int = fib.fib(n)
 }
-
 
 trait LoopFib extends Fib {
   def fib(n: Int): Int = {
@@ -61,41 +56,4 @@ trait TailRecFib extends Fib {
 
 trait Fib {
   def fib(n: Int): Int
-  //  = {
-  //   if (n <= 1) {
-  //     n
-  //   } else {
-  //     fib(n - 1) + fib(n - 2)
-  //   }
-  // }
-
 }
-
-//
-//
-// object Bar {
-//   def bar(b: Base) = b.base
-// }
-
-// class Base extends Incr {
-//   override def incr(x: Int) = foo(x) + 1
-// }
-//
-// trait Incr extends BaseTrait {
-//     // val one = 1
-//     def incr(x: Int): Int
-// }
-//
-// trait BaseTrait {
-//     def foo(x: Int) = x
-// }
-
-// object Foo {
-//     def foo =
-//         Main.ident(1)
-// }
-//
-// class Derived(override val i: Int) extends Base(i) {
-//     def derived(x: Int) = x * i
-//     override def base(x: Int): Int = x * i
-// }

--- a/test-suite/src/main/scala/testsuite/core/ArrayTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/ArrayTest.scala
@@ -1,0 +1,36 @@
+package testsuite.core
+
+import testsuite.Assert
+
+object ArrayTest {
+  def main(): Unit = {
+    Assert.ok(
+      testLength() && testSelect() && testNew()
+    )
+  }
+
+  def testLength(): Boolean = {
+    Array(1, 2, 3).length == 3 &&
+    (Array(Array(1, 2), Array(2), Array(3))).length == 3
+  }
+
+  def testSelect(): Boolean = {
+    val a = Array(Array(1), Array(2), Array(3))
+    a(0)(0) == 1 && {
+      a(0)(0) = 100 // Assign(ArraySelect(...), ...)
+      a(0)(0) == 100 // ArraySelect(...)
+    } && {
+      a(1) = Array(1, 2, 3)
+      a(1).length == 3 && a(1)(0) == 1
+    }
+  }
+
+  def testNew(): Boolean = {
+    (Array.emptyBooleanArray.length == 0) &&
+    (new Array[Int](10)).length == 10 &&
+    (new Array[Int](1))(0) == 0 &&
+    (new Array[Array[Array[Int]]](5))(0) == null
+  }
+
+  // TODO: Array.ofDim[T](...)
+}

--- a/wasm/src/main/scala/ir2wasm/TypeTransformer.scala
+++ b/wasm/src/main/scala/ir2wasm/TypeTransformer.scala
@@ -45,7 +45,7 @@ object TypeTransformer {
 
       case tpe: IRTypes.ArrayType =>
         Types.WasmRefNullType(
-          Types.WasmHeapType.Type(Names.WasmTypeName.WasmArrayTypeName(tpe))
+          Types.WasmHeapType.Type(Names.WasmTypeName.WasmArrayTypeName(tpe.arrayTypeRef))
         )
       case IRTypes.ClassType(className) => transformClassByName(className)
       case IRTypes.RecordType(fields)   => ???

--- a/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
@@ -148,9 +148,6 @@ private class WasmExpressionBuilder private (
       case t: IRTrees.NewArray    => genNewArray(t)
       case t: IRTrees.ArraySelect => genArraySelect(t)
       case t: IRTrees.ArrayValue  => genArrayValue(t)
-      case t: IRTrees.Throw =>
-        instrs += UNREACHABLE // Implement Exception Handling (Throwable doesn't compile yet)
-        IRTypes.NothingType
       case _ =>
         println(tree)
         ???
@@ -160,12 +157,6 @@ private class WasmExpressionBuilder private (
       // case IRTrees.RecordValue(pos) =>
       // case IRTrees.JSNewTarget(pos) =>
       // case IRTrees.SelectStatic(tpe) =>
-      // case IRTrees.IsInstanceOf(pos) =>
-      // case IRTrees.JSLinkingInfo(pos) =>
-      // case IRTrees.Select(tpe) =>
-      // case IRTrees.Return(pos) =>
-      // case IRTrees.While(pos) =>
-      // case IRTrees.LoadJSConstructor(pos) =>
       // case IRTrees.JSSuperMethodCall(pos) =>
       // case IRTrees.Match(tpe) =>
       // case IRTrees.Closure(pos) =>

--- a/wasm/src/main/scala/wasm4s/Defaults.scala
+++ b/wasm/src/main/scala/wasm4s/Defaults.scala
@@ -6,8 +6,8 @@ import wasm.wasm4s.WasmInstr
 import wasm.wasm4s.WasmInstr._
 
 object Defaults {
-  private def nonDefaultable(t: WasmType) = throw new Error(s"Non defaultable type: $t")
-  def defaultValue(t: WasmType): WasmInstr = t match {
+  private def nonDefaultable(t: WasmStorageType) = throw new Error(s"Non defaultable type: $t")
+  def defaultValue(t: WasmStorageType): WasmInstr = t match {
     case WasmUnreachableType       => UNREACHABLE
     case WasmInt32                 => I32_CONST(I32(0))
     case WasmAnyRef                => REF_NULL(HeapType(WasmHeapType.Simple.Any))
@@ -21,6 +21,8 @@ object Defaults {
     case WasmRefNullType(heapType) => REF_NULL(HeapType(heapType))
     case WasmInt64                 => I64_CONST(I64(0))
     case WasmFloat64               => F64_CONST(F64(0))
-    case WasmNoType => nonDefaultable(t)
+    case WasmInt16                 => nonDefaultable(t)
+    case WasmInt8                  => nonDefaultable(t)
+    case WasmNoType                => nonDefaultable(t)
   }
 }

--- a/wasm/src/main/scala/wasm4s/Names.scala
+++ b/wasm/src/main/scala/wasm4s/Names.scala
@@ -337,11 +337,8 @@ object Names {
     final case class WasmArrayTypeName private (override private[wasm4s] val name: String)
         extends WasmTypeName(name)
     object WasmArrayTypeName {
-      def apply(ty: IRTypes.ArrayType) = {
-        val ref = ty.arrayTypeRef
-        // TODO: better naming?
-        new WasmArrayTypeName(s"array_${ref.base.displayName}_${ref.dimensions}")
-      }
+      def apply(typeRef: IRTypes.ArrayTypeRef) =
+        new WasmArrayTypeName(s"arrayOf_${typeRef.base.displayName}_${typeRef.dimensions}")
       val itables = new WasmArrayTypeName("itable")
       val u16Array = new WasmArrayTypeName("u16Array")
     }

--- a/wasm/src/main/scala/wasm4s/Names.scala
+++ b/wasm/src/main/scala/wasm4s/Names.scala
@@ -250,6 +250,7 @@ object Names {
     val itable = new WasmFieldName("itable")
     val itables = new WasmFieldName("itables")
     val u16Array = new WasmFieldName("u16Array")
+    val arrayField = new WasmFieldName("array_field")
 
     // Fields of the typeData structs
     object typeData {
@@ -339,7 +340,7 @@ object Names {
       def apply(ty: IRTypes.ArrayType) = {
         val ref = ty.arrayTypeRef
         // TODO: better naming?
-        new WasmArrayTypeName(s"${ref.base.displayName}_${ref.dimensions}")
+        new WasmArrayTypeName(s"array_${ref.base.displayName}_${ref.dimensions}")
       }
       val itables = new WasmArrayTypeName("itable")
       val u16Array = new WasmArrayTypeName("u16Array")

--- a/wasm/src/main/scala/wasm4s/Wasm.scala
+++ b/wasm/src/main/scala/wasm4s/Wasm.scala
@@ -128,7 +128,7 @@ object WasmStructType {
 }
 
 case class WasmArrayType(
-    name: WasmTypeName,
+    name: WasmTypeName.WasmArrayTypeName,
     field: WasmStructField
 ) extends WasmGCTypeDefinition
 object WasmArrayType {
@@ -176,6 +176,7 @@ object WasmElement {
   */
 class WasmModule(
     private val _functionTypes: mutable.ListBuffer[WasmFunctionType] = new mutable.ListBuffer(),
+    private val _arrayTypes: mutable.Set[WasmArrayType] = new mutable.HashSet(),
     private val _recGroupTypes: mutable.ListBuffer[WasmStructType] = new mutable.ListBuffer(),
     // val importsInOrder: List[WasmNamedModuleField] = Nil,
     private val _imports: mutable.ListBuffer[WasmImport] = new mutable.ListBuffer(),
@@ -197,6 +198,7 @@ class WasmModule(
 ) {
   def addImport(imprt: WasmImport): Unit = _imports.addOne(imprt)
   def addFunction(function: WasmFunction): Unit = _definedFunctions.addOne(function)
+  def addArrayType(typ: WasmArrayType): Unit = _arrayTypes.addOne(typ)
   def addFunctionType(typ: WasmFunctionType): Unit = _functionTypes.addOne(typ)
   def addRecGroupType(typ: WasmStructType): Unit = _recGroupTypes.addOne(typ)
   def addGlobal(typ: WasmGlobal): Unit = _globals.addOne(typ)
@@ -206,7 +208,7 @@ class WasmModule(
 
   def functionTypes = _functionTypes.toList
   def recGroupTypes = WasmModule.tsort(_recGroupTypes.toList)
-  def arrayTypes = List(WasmArrayType.itables, WasmArrayType.u16Array)
+  def arrayTypes = List(WasmArrayType.itables, WasmArrayType.u16Array) ++ _arrayTypes.toList
   def imports = _imports.toList
   def definedFunctions = _definedFunctions.toList
   def globals = _globals.toList

--- a/wasm/src/main/scala/wasm4s/WasmContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmContext.scala
@@ -108,7 +108,7 @@ trait ReadOnlyWasmContext {
   }
 }
 
-trait FunctionTypeWriterWasmContext extends ReadOnlyWasmContext { this: WasmContext =>
+trait TypeDefinableWasmContext extends ReadOnlyWasmContext { this: WasmContext =>
   protected val functionSignatures = LinkedHashMap.empty[WasmFunctionSignature, Int]
   protected val constantStringGlobals = LinkedHashMap.empty[String, WasmGlobalName]
 
@@ -163,9 +163,12 @@ trait FunctionTypeWriterWasmContext extends ReadOnlyWasmContext { this: WasmCont
     addFuncDeclaration(name)
     WasmInstr.REF_FUNC(WasmImmediate.FuncIdx(name))
   }
+
+  def addArrayType(ty: WasmArrayType): Unit =
+    module.addArrayType(ty)
 }
 
-class WasmContext(val module: WasmModule) extends FunctionTypeWriterWasmContext {
+class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
   import WasmContext._
 
   private val _startInstructions: mutable.ListBuffer[WasmInstr] = new mutable.ListBuffer()
@@ -419,7 +422,7 @@ object WasmContext {
       // flags: IRTrees.MemberFlags,
       isAbstract: Boolean
   ) {
-    def toWasmFunctionType()(implicit ctx: FunctionTypeWriterWasmContext): WasmFunctionType =
+    def toWasmFunctionType()(implicit ctx: TypeDefinableWasmContext): WasmFunctionType =
       TypeTransformer.transformFunctionType(this)
 
   }


### PR DESCRIPTION
~Better to work based on https://github.com/tanishiking/scala-wasm/pull/15 for `js.Iterable`...~

Implement fundamental monomorphic array

- Generic array doesn't compile yet e.g. `Array.ofDim` because of https://github.com/scala-js/scala-js/blob/8dd02c784818d6d3d4a18ebf53cc0797212ef12e/javalib/src/main/scala/java/lang/Integer.scala#L56
- We would need to box Array so that it is a subtype of `java.lang.Object`(?) can we box it in `scala.Array` like `char` and `long`?