### PR TITLE
Implement support for classOf and getClass.

### DIFF
--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -8,6 +8,7 @@ object TestSuites {
     TestSuite("testsuite.core.VirtualDispatch"),
     TestSuite("testsuite.core.InterfaceCall"),
     TestSuite("testsuite.core.AsInstanceOfTest"),
+    TestSuite("testsuite.core.ClassOfTest"),
     TestSuite("testsuite.core.JSInteropTest"),
     TestSuite("testsuite.core.HijackedClassesDispatchTest"),
     TestSuite("testsuite.core.HijackedClassesMonoTest"),

--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -9,6 +9,7 @@ object TestSuites {
     TestSuite("testsuite.core.InterfaceCall"),
     TestSuite("testsuite.core.AsInstanceOfTest"),
     TestSuite("testsuite.core.ClassOfTest"),
+    TestSuite("testsuite.core.GetClassTest"),
     TestSuite("testsuite.core.JSInteropTest"),
     TestSuite("testsuite.core.HijackedClassesDispatchTest"),
     TestSuite("testsuite.core.HijackedClassesMonoTest"),

--- a/loader.mjs
+++ b/loader.mjs
@@ -77,6 +77,32 @@ const scalaJSHelpers = {
   stringConcat: (x, y) => ("" + x) + y, // the added "" is for the case where x === y === null
   isString: (x) => typeof x === 'string',
 
+  /* Get the type of JS value of `x` in a single JS helper call, for the purpose of dispatch.
+   *
+   * 0: false
+   * 1: true
+   * 2: string
+   * 3: number
+   * 4: undefined
+   * 5: everything else
+   *
+   * This encoding has the following properties:
+   *
+   * - false and true also return their value as the appropriate i32.
+   * - the types implementing `Comparable` are consecutive from 0 to 3.
+   */
+  jsValueType: (x) => {
+    if (typeof x === 'number')
+      return 3;
+    if (typeof x === 'string')
+      return 2;
+    if (typeof x === 'boolean')
+      return x | 0;
+    if (typeof x === 'undefined')
+      return 4;
+    return 5;
+  },
+
   // Hash code, because it is overridden in all hijacked classes
   // Specified by the hashCode() method of the corresponding hijacked classes
   jsValueHashCode: (x) => {

--- a/loader.mjs
+++ b/loader.mjs
@@ -61,6 +61,9 @@ const scalaJSHelpers = {
   tF: (x) => typeof x === 'number' && (Math.fround(x) === x || x !== x),
   tD: (x) => typeof x === 'number',
 
+  // Closure
+  closure: (f, data) => f.bind(void 0, data),
+
   // Strings
   emptyString: () => "",
   stringLength: (s) => s.length,

--- a/test-suite/src/main/scala/testsuite/Assert.scala
+++ b/test-suite/src/main/scala/testsuite/Assert.scala
@@ -14,4 +14,7 @@ package testsuite
 object Assert {
   def ok(cond: Boolean): Unit =
     if (!cond) null.toString() // Apply to Null should compile to unreachable
+
+  def assertSame(expected: Any, actual: Any): Unit =
+    ok(expected.asInstanceOf[AnyRef] eq actual.asInstanceOf[AnyRef])
 }

--- a/test-suite/src/main/scala/testsuite/core/ClassOfTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/ClassOfTest.scala
@@ -1,0 +1,117 @@
+package testsuite.core
+
+import testsuite.Assert.ok
+import testsuite.Assert
+
+object ClassOfTest {
+  def main(): Unit = {
+    testGetName()
+    testUniqueness()
+    testIsPrimitive()
+    testIsInterface()
+    testIsArray()
+    testGetComponentType()
+  }
+
+  def testGetName(): Unit = {
+    Assert.assertSame("java.lang.String", classOf[String].getName())
+    Assert.assertSame("java.lang.StringBuilder", classOf[java.lang.StringBuilder].getName())
+    Assert.assertSame("int", classOf[Int].getName())
+    Assert.assertSame("void", classOf[Unit].getName())
+
+    Assert.assertSame("[Ljava.lang.Object;", classOf[Array[AnyRef]].getName())
+    Assert.assertSame("[Ljava.lang.String;", classOf[Array[String]].getName())
+    Assert.assertSame("[[Ljava.lang.CharSequence;", classOf[Array[Array[CharSequence]]].getName())
+
+    Assert.assertSame("[Z", classOf[Array[Boolean]].getName())
+    Assert.assertSame("[C", classOf[Array[Char]].getName())
+    Assert.assertSame("[B", classOf[Array[Byte]].getName())
+    Assert.assertSame("[S", classOf[Array[Short]].getName())
+    Assert.assertSame("[I", classOf[Array[Int]].getName())
+    Assert.assertSame("[J", classOf[Array[Long]].getName())
+    Assert.assertSame("[F", classOf[Array[Float]].getName())
+    Assert.assertSame("[D", classOf[Array[Double]].getName())
+  }
+
+  def testUniqueness(): Unit = {
+    Assert.assertSame(classOf[String], classOf[String])
+    Assert.assertSame(classOf[java.lang.StringBuilder], classOf[java.lang.StringBuilder])
+    Assert.assertSame(classOf[CharSequence], classOf[CharSequence])
+    Assert.assertSame(classOf[Int], classOf[Int])
+
+    Assert.assertSame(classOf[Array[Int]], classOf[Array[Int]])
+    Assert.assertSame(classOf[Array[Array[java.lang.Byte]]], classOf[Array[Array[java.lang.Byte]]])
+    Assert.assertSame(classOf[Array[Array[Int]]], classOf[Array[Array[Int]]])
+  }
+
+  def testIsPrimitive(): Unit = {
+    Assert.assertSame(false, classOf[AnyRef].isPrimitive())
+    Assert.assertSame(false, classOf[String].isPrimitive())
+    Assert.assertSame(false, classOf[CharSequence].isPrimitive())
+    Assert.assertSame(false, classOf[java.lang.Iterable[Any]].isPrimitive())
+    Assert.assertSame(false, classOf[Array[Int]].isPrimitive())
+    Assert.assertSame(false, classOf[Array[String]].isPrimitive())
+    Assert.assertSame(false, classOf[Array[CharSequence]].isPrimitive())
+
+    Assert.assertSame(true, classOf[Int].isPrimitive())
+    Assert.assertSame(true, classOf[Unit].isPrimitive())
+  }
+
+  def testIsInterface(): Unit = {
+    Assert.assertSame(false, classOf[AnyRef].isInterface())
+    Assert.assertSame(false, classOf[String].isInterface())
+    Assert.assertSame(false, classOf[Int].isInterface())
+    Assert.assertSame(false, classOf[Array[Int]].isInterface())
+    Assert.assertSame(false, classOf[Array[String]].isInterface())
+    Assert.assertSame(false, classOf[Array[CharSequence]].isInterface())
+
+    Assert.assertSame(true, classOf[CharSequence].isInterface())
+    Assert.assertSame(true, classOf[java.lang.Iterable[Any]].isInterface())
+  }
+
+  def testIsArray(): Unit = {
+    Assert.assertSame(false, classOf[AnyRef].isArray())
+    Assert.assertSame(false, classOf[String].isArray())
+    Assert.assertSame(false, classOf[Int].isArray())
+    Assert.assertSame(false, classOf[CharSequence].isArray())
+    Assert.assertSame(false, classOf[java.lang.Iterable[Any]].isArray())
+
+    Assert.assertSame(true, classOf[Array[Int]].isArray())
+    Assert.assertSame(true, classOf[Array[String]].isArray())
+    Assert.assertSame(true, classOf[Array[CharSequence]].isArray())
+  }
+
+  def testGetComponentType(): Unit = {
+    Assert.assertSame(null, classOf[AnyRef].getComponentType())
+    Assert.assertSame(null, classOf[String].getComponentType())
+    Assert.assertSame(null, classOf[Int].getComponentType())
+    Assert.assertSame(null, classOf[CharSequence].getComponentType())
+    Assert.assertSame(null, classOf[java.lang.Iterable[Any]].getComponentType())
+
+    Assert.assertSame(classOf[Int], classOf[Array[Int]].getComponentType())
+    Assert.assertSame(classOf[String], classOf[Array[String]].getComponentType())
+    Assert.assertSame(classOf[AnyRef], classOf[Array[AnyRef]].getComponentType())
+
+    Assert.assertSame(
+      classOf[Array[CharSequence]],
+      classOf[Array[Array[CharSequence]]].getComponentType()
+    )
+
+    Assert.assertSame(
+      classOf[Array[Long]],
+      classOf[Array[Array[Long]]].getComponentType()
+    )
+
+    Assert.assertSame(
+      classOf[Array[Array[java.lang.Byte]]],
+      classOf[Array[Array[Array[java.lang.Byte]]]].getComponentType()
+    )
+
+    Assert.assertSame(
+      classOf[Array[ClassForUniqueGetComponentTypeTest]].getComponentType(),
+      classOf[Array[ClassForUniqueGetComponentTypeTest]].getComponentType()
+    )
+  }
+
+  class ClassForUniqueGetComponentTypeTest
+}

--- a/test-suite/src/main/scala/testsuite/core/GetClassTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/GetClassTest.scala
@@ -1,0 +1,52 @@
+package testsuite.core
+
+import testsuite.Assert.assertSame
+
+object GetClassTest {
+  def main(): Unit = {
+    testNoHijackedDispatch()
+    testWithHijackedDispath()
+  }
+
+  class Foo
+
+  class Bar extends Foo
+
+  def testNoHijackedDispatch(): Unit = {
+    def getClassOfFoo(x: Foo): Class[_] = x.getClass()
+
+    assertSame(classOf[Foo], getClassOfFoo(new Foo))
+    assertSame(classOf[Bar], getClassOfFoo(new Bar))
+  }
+
+  def testWithHijackedDispath(): Unit = {
+    def getClassOf(x: Any): Class[_] = x.getClass()
+
+    assertSame(classOf[Foo], getClassOf(new Foo))
+    assertSame(classOf[Bar], getClassOf(new Bar))
+
+    assertSame(classOf[java.lang.Boolean], getClassOf(true))
+    assertSame(classOf[java.lang.Boolean], getClassOf(false))
+    assertSame(classOf[java.lang.Void], getClassOf(()))
+    assertSame(classOf[java.lang.String], getClassOf("foo"))
+
+    assertSame(classOf[java.lang.Byte], getClassOf(0.0))
+    assertSame(classOf[java.lang.Byte], getClassOf(56))
+    assertSame(classOf[java.lang.Byte], getClassOf(-128))
+    assertSame(classOf[java.lang.Short], getClassOf(200))
+    assertSame(classOf[java.lang.Short], getClassOf(-32000))
+    assertSame(classOf[java.lang.Integer], getClassOf(500000))
+    assertSame(classOf[java.lang.Integer], getClassOf(Int.MinValue))
+
+    assertSame(classOf[java.lang.Float], getClassOf(1.5))
+    assertSame(classOf[java.lang.Double], getClassOf(1.4))
+    assertSame(classOf[java.lang.Double], getClassOf(Float.MaxValue.toDouble * 8.0))
+
+    assertSame(classOf[java.lang.Float], getClassOf(-0.0))
+    assertSame(classOf[java.lang.Float], getClassOf(Double.PositiveInfinity))
+    assertSame(classOf[java.lang.Float], getClassOf(Double.NegativeInfinity))
+    assertSame(classOf[java.lang.Float], getClassOf(Double.NaN))
+
+    assertSame(null, getClassOf(scala.scalajs.js.Math))
+  }
+}

--- a/wasm/src/main/scala/Compiler.scala
+++ b/wasm/src/main/scala/Compiler.scala
@@ -4,8 +4,7 @@ import wasm.ir2wasm._
 import wasm.wasm4s._
 
 import org.scalajs.ir
-import org.scalajs.ir.Trees._
-import org.scalajs.ir.Types._
+import org.scalajs.ir.{Names => IRNames}
 
 import org.scalajs.linker.interface._
 import org.scalajs.linker.standard._
@@ -46,6 +45,7 @@ object Compiler {
      */
     val factory = SymbolRequirement.factory("wasm")
     val symbolRequirements = factory.multiple(
+      factory.instantiateClass(IRNames.ClassClass, SpecialNames.ClassCtor),
       factory.instantiateClass(SpecialNames.CharBoxClass, SpecialNames.CharBoxCtor),
       factory.instantiateClass(SpecialNames.LongBoxClass, SpecialNames.LongBoxCtor)
     )
@@ -70,6 +70,8 @@ object Compiler {
 
       Preprocessor.preprocess(sortedClasses)(context)
       println("preprocessed")
+      HelperFunctions.genGlobalHelpers()
+      builder.genPrimitiveTypeDataGlobals()
       sortedClasses.foreach { clazz =>
         builder.transformClassDef(clazz)
       }

--- a/wasm/src/main/scala/converters/WasmBinaryWriter.scala
+++ b/wasm/src/main/scala/converters/WasmBinaryWriter.scala
@@ -278,7 +278,7 @@ final class WasmBinaryWriter(module: WasmModule) {
 
       case FuncIdx(value)        => writeFuncIdx(buf, value)
       case labelIdx: LabelIdx    => writeLabelIdx(buf, labelIdx)
-      case LabelIdxVector(value) => ???
+      case LabelIdxVector(value) => buf.vec(value)(writeLabelIdx(buf, _))
       case TypeIdx(value)        => writeTypeIdx(buf, value)
       case TableIdx(value)       => ???
       case TagIdx(value)         => ???

--- a/wasm/src/main/scala/converters/WasmTextWriter.scala
+++ b/wasm/src/main/scala/converters/WasmTextWriter.scala
@@ -30,6 +30,7 @@ class WasmTextWriter {
         module.globals.foreach(writeGlobal)
         module.exports.foreach(writeExport)
         module.startFunction.foreach(writeStart)
+        module.elements.foreach(writeElement)
       }
     )
     // context.gcTypes
@@ -199,6 +200,24 @@ class WasmTextWriter {
     b.newLineList(
       "start", {
         b.appendElement(startFunction.show)
+      }
+    )
+  }
+
+  private def writeElement(element: WasmElement)(implicit b: WatBuilder): Unit = {
+    b.newLineList(
+      "elem", {
+        element.mode match {
+          case WasmElement.Mode.Passive     => ()
+          case WasmElement.Mode.Declarative => b.appendElement("declare")
+        }
+        b.appendElement(element.typ.show)
+        element.init.foreach { item =>
+          b.newLineList(
+            "item",
+            item.instr.foreach(writeInstr(_))
+          )
+        }
       }
     )
   }

--- a/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
+++ b/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
@@ -1,0 +1,457 @@
+package wasm.ir2wasm
+
+import org.scalajs.ir.{Trees => IRTrees}
+import org.scalajs.ir.{Types => IRTypes}
+import org.scalajs.ir.{Names => IRNames}
+
+import wasm.wasm4s._
+import wasm.wasm4s.WasmContext._
+import wasm.wasm4s.Names._
+import wasm.wasm4s.Types._
+import wasm.wasm4s.WasmInstr._
+
+import TypeTransformer._
+
+object HelperFunctions {
+
+  def genGlobalHelpers()(implicit ctx: WasmContext): Unit = {
+    genCreateStringFromData()
+    genTypeDataName()
+    genCreateClassOf()
+    genArrayTypeData()
+    genGetComponentType()
+  }
+
+  /** `createStringFromData: (ref array u16) -> (ref any)` (representing a `string`). */
+  private def genCreateStringFromData()(implicit ctx: WasmContext): Unit = {
+    import WasmImmediate._
+    import WasmTypeName.WasmArrayTypeName
+
+    val dataType = WasmRefType(WasmHeapType.Type(WasmArrayTypeName.u16Array))
+
+    val fctx = WasmFunctionContext(
+      WasmFunctionName.createStringFromData,
+      List("data" -> dataType),
+      List(WasmRefType.any)
+    )
+
+    val List(dataParam) = fctx.paramIndices
+
+    import fctx.instrs
+
+    val lenLocal = fctx.addLocal("len", WasmInt32)
+    val iLocal = fctx.addLocal("i", WasmInt32)
+    val resultLocal = fctx.addLocal("restul", WasmRefType.any)
+
+    // len := data.length
+    instrs += LOCAL_GET(dataParam)
+    instrs += ARRAY_LEN
+    instrs += LOCAL_SET(lenLocal)
+
+    // i := 0
+    instrs += I32_CONST(I32(0))
+    instrs += LOCAL_SET(iLocal)
+
+    // result := ""
+    instrs += CALL(FuncIdx(WasmFunctionName.emptyString))
+    instrs += LOCAL_SET(resultLocal)
+
+    fctx.loop() { labelLoop =>
+      // if i == len
+      instrs += LOCAL_GET(iLocal)
+      instrs += LOCAL_GET(lenLocal)
+      instrs += I32_EQ
+      fctx.ifThen() {
+        // then return result
+        instrs += LOCAL_GET(resultLocal)
+        instrs += RETURN
+      }
+
+      // result := concat(result, charToString(data(i)))
+      instrs += LOCAL_GET(resultLocal)
+      instrs += LOCAL_GET(dataParam)
+      instrs += LOCAL_GET(iLocal)
+      instrs += ARRAY_GET_U(TypeIdx(WasmArrayTypeName.u16Array))
+      instrs += CALL(FuncIdx(WasmFunctionName.charToString))
+      instrs += CALL(FuncIdx(WasmFunctionName.stringConcat))
+      instrs += LOCAL_SET(resultLocal)
+
+      // i := i - 1
+      instrs += LOCAL_GET(iLocal)
+      instrs += I32_CONST(I32(1))
+      instrs += I32_ADD
+      instrs += LOCAL_SET(iLocal)
+
+      // loop back to the beginning
+      instrs += BR(labelLoop)
+    } // end loop $loop
+    instrs += UNREACHABLE
+
+    fctx.buildAndAddToContext()
+  }
+
+  /** `typeDataName: (ref typeData) -> (ref any)` (representing a `string`).
+   *
+   *  Initializes the `name` field of the given `typeData` if that was not done
+   *  yet, and returns its value.
+   *
+   *  The computed value is specified by `java.lang.Class.getName()`. See also
+   *  the documentation on [[Names.WasmFieldName.typeData.name]] for details.
+   *
+   *  @see [[https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Class.html#getName()]]
+   */
+  private def genTypeDataName()(implicit ctx: WasmContext): Unit = {
+    import WasmImmediate._
+    import WasmTypeName._
+
+    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
+    val nameDataType = WasmRefType(WasmHeapType.Type(WasmArrayTypeName.u16Array))
+
+    val u16ArrayIdx = TypeIdx(WasmArrayTypeName.u16Array)
+
+    val fctx = WasmFunctionContext(
+      WasmFunctionName.typeDataName,
+      List("typeData" -> typeDataType),
+      List(WasmRefType.any)
+    )
+
+    val List(typeDataParam) = fctx.paramIndices
+
+    import fctx.instrs
+
+    val componentTypeDataLocal = fctx.addLocal("componentTypeData", typeDataType)
+    val componentNameDataLocal = fctx.addLocal("componentNameData", nameDataType)
+    val firstCharLocal = fctx.addLocal("firstChar", WasmInt32)
+    val nameLocal = fctx.addLocal("name", WasmRefType.any)
+
+    fctx.block(WasmRefType.any) { alreadyInitializedLabel =>
+      // br_on_non_null $alreadyInitialized typeData.name
+      instrs += LOCAL_GET(typeDataParam)
+      instrs += STRUCT_GET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.nameIdx)
+      instrs += BR_ON_NON_NULL(alreadyInitializedLabel)
+
+      // for the STRUCT_SET typeData.name near the end
+      instrs += LOCAL_GET(typeDataParam)
+
+      // if typeData.kind == 2 (isArray)
+      instrs += LOCAL_GET(typeDataParam)
+      instrs += STRUCT_GET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.kindIdx)
+      instrs += I32_CONST(I32(2))
+      instrs += I32_EQ
+      fctx.ifThenElse(WasmRefType.any) {
+        // it is an array; compute its name from the component type name
+
+        // <top of stack> := "[", for the CALL to stringConcat near the end
+        instrs += I32_CONST(I32('['.toInt))
+        instrs += CALL(FuncIdx(WasmFunctionName.charToString))
+
+        // componentTypeData := ref_as_non_null(typeData.componentType)
+        instrs += LOCAL_GET(typeDataParam)
+        instrs += STRUCT_GET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.componentTypeIdx)
+        instrs += REF_AS_NOT_NULL
+        instrs += LOCAL_TEE(componentTypeDataLocal)
+
+        // if componentTypeData.kind == 1 (primitive)
+        instrs += STRUCT_GET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.kindIdx)
+        instrs += I32_CONST(I32(1))
+        instrs += I32_EQ
+        fctx.ifThenElse(WasmRefType.any) { // returns the string that must come after "["
+          // the component type is a primitive; compute its charCode from its name's first and second chars
+
+          // componentNameData := componentTypeData.nameData
+          instrs += LOCAL_GET(componentTypeDataLocal)
+          instrs += STRUCT_GET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.nameDataIdx)
+          instrs += REF_AS_NOT_NULL
+          instrs += LOCAL_TEE(componentNameDataLocal)
+
+          // firstChar := componentNameData(0)
+          instrs += I32_CONST(I32(0))
+          instrs += ARRAY_GET_U(u16ArrayIdx)
+          instrs += LOCAL_TEE(firstCharLocal)
+
+          // if firstChar == 'b'
+          instrs += I32_CONST(I32('b'.toInt))
+          instrs += I32_EQ
+          fctx.ifThenElse(WasmInt32) {
+            // 'b' can be 'byte' or 'boolean'; check second char
+
+            // if componentNameData(1) == 'o'
+            instrs += LOCAL_GET(componentNameDataLocal)
+            instrs += I32_CONST(I32(1)) // second char
+            instrs += ARRAY_GET_U(u16ArrayIdx)
+            instrs += I32_CONST(I32('o'.toInt))
+            instrs += I32_EQ
+            fctx.ifThenElse(WasmInt32) {
+              // if 'o', it's 'boolean'
+              instrs += I32_CONST(I32('Z'.toInt))
+            } {
+              // otherwise, it is 'byte'
+              instrs += I32_CONST(I32('B'.toInt))
+            }
+          } {
+            // if firstChar == 'l'
+            instrs += LOCAL_GET(firstCharLocal)
+            instrs += I32_CONST(I32('l'.toInt))
+            instrs += I32_EQ
+            fctx.ifThenElse(WasmInt32) {
+              // 'l' is 'long', which must become 'J'
+              instrs += I32_CONST(I32('J'.toInt))
+            } {
+              // Other letters are turned into their uppercase, which is 32 less
+              instrs += LOCAL_GET(firstCharLocal)
+              instrs += I32_CONST(I32(32))
+              instrs += I32_SUB
+            }
+          }
+
+          // convert the charCode to string
+          instrs += CALL(FuncIdx(WasmFunctionName.charToString))
+        } {
+          // the component type is not a primitive
+
+          // if componentTypeData.kind == 2 (array)
+          instrs += LOCAL_GET(componentTypeDataLocal)
+          instrs += STRUCT_GET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.kindIdx)
+          instrs += I32_CONST(I32(2))
+          instrs += I32_EQ
+          fctx.ifThenElse(WasmRefType.any) {
+            // the component type is an array; get its own name
+            instrs += LOCAL_GET(componentTypeDataLocal)
+            instrs += CALL(FuncIdx(WasmFunctionName.typeDataName))
+          } {
+            // the component type is neither a primitive nor an array;
+            // concatenate "L" + <its own name> + ";"
+            instrs += I32_CONST(I32('L'.toInt))
+            instrs += CALL(FuncIdx(WasmFunctionName.charToString))
+            instrs += LOCAL_GET(componentTypeDataLocal)
+            instrs += CALL(FuncIdx(WasmFunctionName.typeDataName))
+            instrs += CALL(FuncIdx(WasmFunctionName.stringConcat))
+            instrs += I32_CONST(I32(';'.toInt))
+            instrs += CALL(FuncIdx(WasmFunctionName.charToString))
+            instrs += CALL(FuncIdx(WasmFunctionName.stringConcat))
+          }
+        }
+
+        // At this point, the stack contains "[" and the string that must be concatenated with it
+        instrs += CALL(FuncIdx(WasmFunctionName.stringConcat))
+      } {
+        // it is not an array; its name is stored in nameData
+        instrs += LOCAL_GET(typeDataParam)
+        instrs += STRUCT_GET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.nameDataIdx)
+        instrs += REF_AS_NOT_NULL
+        instrs += CALL(FuncIdx(WasmFunctionName.createStringFromData))
+      }
+
+      // typeData.name := <top of stack> ; leave it on the stack
+      instrs += LOCAL_TEE(nameLocal)
+      instrs += STRUCT_SET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.nameIdx)
+      instrs += LOCAL_GET(nameLocal)
+    }
+
+    fctx.buildAndAddToContext()
+  }
+
+  /** `createClassOf: (ref typeData) -> (ref jlClass)`.
+   *
+   *  Creates the unique `java.lang.Class` instance associated with the given
+   *  `typeData`, stores it in its `classOfValue` field, and returns it.
+   *
+   *  Must be called only if the `classOfValue` of the typeData is null. All
+   *  call sites must deal with the non-null case as a fast-path.
+   */
+  private def genCreateClassOf()(implicit ctx: WasmContext): Unit = {
+    import WasmImmediate._
+    import WasmTypeName.WasmStructTypeName
+
+    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
+
+    val fctx = WasmFunctionContext(
+      WasmFunctionName.createClassOf,
+      List("typeData" -> typeDataType),
+      List(WasmRefType(WasmHeapType.ClassType))
+    )
+
+    val List(typeDataParam) = fctx.paramIndices
+
+    import fctx.instrs
+
+    val classInstanceLocal = fctx.addLocal("classInstance", WasmRefType(WasmHeapType.ClassType))
+
+    // classInstance := newDefault$java.lang.Class()
+    // leave it on the stack for the constructor call
+    instrs += CALL(FuncIdx(WasmFunctionName.newDefault(IRNames.ClassClass)))
+    instrs += LOCAL_TEE(classInstanceLocal)
+
+    /* The JS object containing metadata to pass as argument to the `jl.Class` constructor.
+     * Specified by https://lampwww.epfl.ch/~doeraene/sjsir-semantics/#sec-sjsir-createclassdataof
+     * Leave it on the stack.
+     */
+    instrs += CALL(FuncIdx(WasmFunctionName.jsNewObject))
+    // "name": typeDataName(typeData)
+    instrs += ctx.getConstantStringInstr("name")
+    instrs += LOCAL_GET(typeDataParam)
+    instrs += CALL(FuncIdx(WasmFunctionName.typeDataName))
+    instrs += CALL(FuncIdx(WasmFunctionName.jsObjectPush))
+    // "isPrimitive": (typeData.kind == 1)
+    instrs += ctx.getConstantStringInstr("isPrimitive")
+    instrs += LOCAL_GET(typeDataParam)
+    instrs += STRUCT_GET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.kindIdx)
+    instrs += I32_CONST(I32(1))
+    instrs += I32_EQ
+    instrs += CALL(FuncIdx(WasmFunctionName.box(IRTypes.BooleanRef)))
+    instrs += CALL(FuncIdx(WasmFunctionName.jsObjectPush))
+    // "isArrayClass": (typeData.kind == 2)
+    instrs += ctx.getConstantStringInstr("isArrayClass")
+    instrs += LOCAL_GET(typeDataParam)
+    instrs += STRUCT_GET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.kindIdx)
+    instrs += I32_CONST(I32(2))
+    instrs += I32_EQ
+    instrs += CALL(FuncIdx(WasmFunctionName.box(IRTypes.BooleanRef)))
+    instrs += CALL(FuncIdx(WasmFunctionName.jsObjectPush))
+    // "isInterface": (typeData.kind == 3)
+    instrs += ctx.getConstantStringInstr("isInterface")
+    instrs += LOCAL_GET(typeDataParam)
+    instrs += STRUCT_GET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.kindIdx)
+    instrs += I32_CONST(I32(3))
+    instrs += I32_EQ
+    instrs += CALL(FuncIdx(WasmFunctionName.box(IRTypes.BooleanRef)))
+    instrs += CALL(FuncIdx(WasmFunctionName.jsObjectPush))
+    // "getComponentType": closure(getComponentType, typeData)
+    instrs += ctx.getConstantStringInstr("getComponentType")
+    instrs += ctx.refFuncWithDeclaration(WasmFunctionName.getComponentType)
+    instrs += LOCAL_GET(typeDataParam)
+    instrs += CALL(FuncIdx(WasmFunctionName.closure))
+    instrs += CALL(FuncIdx(WasmFunctionName.jsObjectPush))
+    // TODO: "isInstance", "isAssignableFrom", "checkCast", "newArrayOfThisClass"
+
+    // Call java.lang.Class::<init>(dataObject)
+    instrs += CALL(FuncIdx(WasmFunctionName(IRNames.ClassClass, SpecialNames.ClassCtor)))
+
+    // typeData.classOf := classInstance
+    instrs += LOCAL_GET(typeDataParam)
+    instrs += LOCAL_GET(classInstanceLocal)
+    instrs += STRUCT_SET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.classOfIdx)
+
+    // <top-of-stack> := classInstance for the implicit return
+    instrs += LOCAL_GET(classInstanceLocal)
+
+    fctx.buildAndAddToContext()
+  }
+
+  /** `arrayTypeData: (ref typeData), i32 -> (ref typeData)`.
+   *
+   *  Returns the typeData of an array with `dims` dimensions over the given
+   *  typeData.
+   */
+  private def genArrayTypeData()(implicit ctx: WasmContext): Unit = {
+    import WasmImmediate._
+    import WasmTypeName.WasmStructTypeName
+
+    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
+
+    val fctx = WasmFunctionContext(
+      WasmFunctionName.arrayTypeData,
+      List("typeData" -> typeDataType, "dims" -> WasmInt32),
+      List(typeDataType)
+    )
+
+    val List(typeDataParam, dimsParam) = fctx.paramIndices
+
+    import fctx.instrs
+
+    fctx.loop() { loopLabel =>
+      // if dims == 0 then
+      //   return typeData
+      instrs += LOCAL_GET(dimsParam)
+      instrs += I32_EQZ
+      fctx.ifThen() {
+        instrs += LOCAL_GET(typeDataParam)
+        instrs += RETURN
+      }
+
+      // dims := dims - 1
+      instrs += LOCAL_GET(dimsParam)
+      instrs += I32_CONST(I32(1))
+      instrs += I32_SUB
+      instrs += LOCAL_SET(dimsParam)
+
+      fctx.block(typeDataType) { arrayOfIsNonNullLabel =>
+        // br_on_non_null $arrayOfIsNonNull typeData.arrayOf
+        instrs += LOCAL_GET(typeDataParam)
+        instrs += STRUCT_GET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.arrayOfIdx)
+        instrs += BR_ON_NON_NULL(arrayOfIsNonNullLabel)
+
+        // <top-of-stack> := typeData ; for the <old typeData>.arrayOf := ... later on
+        instrs += LOCAL_GET(typeDataParam)
+
+        // typeData := new typeData(...)
+        instrs += REF_NULL(HeapType(WasmHeapType.Simple.None)) // nameData
+        instrs += I32_CONST(I32(2)) // kind = isArray
+        instrs += LOCAL_GET(typeDataParam) // componentType
+        instrs += REF_NULL(HeapType(WasmHeapType.Simple.None)) // name
+        instrs += REF_NULL(HeapType(WasmHeapType.Simple.None)) // classOf
+        instrs += REF_NULL(HeapType(WasmHeapType.Simple.None)) // arrayOf
+        instrs += STRUCT_NEW(TypeIdx(WasmStructTypeName.typeData))
+        instrs += LOCAL_TEE(typeDataParam)
+
+        // <old typeData>.arrayOf := typeData
+        instrs += STRUCT_SET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.arrayOfIdx)
+
+        // loop back to the beginning
+        instrs += BR(loopLabel)
+      } // end block $arrayOfIsNonNullLabel
+
+      // typeData := typeData.arrayOf (which is on the stack), then loop back to the beginning
+      instrs += LOCAL_SET(typeDataParam)
+      instrs += BR(loopLabel)
+    } // end loop $loop
+    instrs += UNREACHABLE
+
+    fctx.buildAndAddToContext()
+  }
+
+  /** `getComponentType: (ref typeData) -> (ref null jlClass)`.
+   *
+   *  This is the underlying func for the `getComponentType()` closure inside
+   *  class data objects.
+   */
+  private def genGetComponentType()(implicit ctx: WasmContext): Unit = {
+    import WasmImmediate._
+    import WasmTypeName.WasmStructTypeName
+
+    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
+
+    val fctx = WasmFunctionContext(
+      WasmFunctionName.getComponentType,
+      List("typeData" -> typeDataType),
+      List(WasmRefNullType(WasmHeapType.ClassType))
+    )
+
+    val List(typeDataParam) = fctx.paramIndices
+
+    import fctx.instrs
+
+    val componentTypeDataLocal = fctx.addLocal("componentTypeData", typeDataType)
+
+    fctx.block() { nullResultLabel =>
+      fctx.block(Types.WasmRefType(Types.WasmHeapType.ClassType)) { nonNullClassOfLabel =>
+        // Try and extract non-null component type data
+        instrs += LOCAL_GET(typeDataParam)
+        instrs += STRUCT_GET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.componentTypeIdx)
+        instrs += BR_ON_NULL(nullResultLabel)
+        // fast path
+        instrs += LOCAL_TEE(componentTypeDataLocal)
+        instrs += STRUCT_GET(TypeIdx(WasmStructTypeName.typeData), WasmFieldName.typeData.classOfIdx)
+        instrs += BR_ON_NON_NULL(nonNullClassOfLabel)
+        // slow path
+        instrs += LOCAL_GET(componentTypeDataLocal)
+        instrs += CALL(FuncIdx(WasmFunctionName.createClassOf))
+      } // end bock nonNullClassOfLabel
+      instrs += RETURN
+    } // end block nullResultLabel
+    instrs += REF_NULL(HeapType(WasmHeapType.ClassType))
+
+    fctx.buildAndAddToContext()
+  }
+
+}

--- a/wasm/src/main/scala/ir2wasm/SpecialNames.scala
+++ b/wasm/src/main/scala/ir2wasm/SpecialNames.scala
@@ -13,4 +13,7 @@ object SpecialNames {
 
   val CharBoxCtor = MethodName.constructor(List(CharRef))
   val LongBoxCtor = MethodName.constructor(List(LongRef))
+
+  // The constructor of java.lang.Class
+  val ClassCtor = MethodName.constructor(List(ClassRef(ObjectClass)))
 }

--- a/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
@@ -192,7 +192,7 @@ class WasmBuilder {
     // Declare the struct type for the class
     val vtableField = WasmStructField(
       Names.WasmFieldName.vtable,
-      WasmRefNullType(WasmHeapType.Type(vtableType.name)),
+      WasmRefType(WasmHeapType.Type(vtableType.name)),
       isMutable = false
     )
     val fields = clazz.fields.map(transformField)

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -332,7 +332,7 @@ object WasmImmediate {
 
   case class FuncIdx(val value: WasmFunctionName) extends WasmImmediate
   case class LabelIdx(val value: Int) extends WasmImmediate
-  case class LabelIdxVector(val value: List[Int]) extends WasmImmediate
+  case class LabelIdxVector(val value: List[LabelIdx]) extends WasmImmediate
   case class TypeIdx(val value: WasmTypeName) extends WasmImmediate
   case class TableIdx(val value: Int) extends WasmImmediate
   case class TagIdx(val value: Int) extends WasmImmediate

--- a/wasm/src/main/scala/wasm4s/Names.scala
+++ b/wasm/src/main/scala/wasm4s/Names.scala
@@ -144,6 +144,7 @@ object Names {
     val stringConcat = helper("stringConcat")
     val isString = helper("isString")
 
+    val jsValueType = helper("jsValueType")
     val jsValueHashCode = helper("jsValueHashCode")
 
     val jsGlobalRefGet = helper("jsGlobalRefGet")
@@ -205,8 +206,10 @@ object Names {
     val createStringFromData = helper("createStringFromData")
     val typeDataName = helper("typeDataName")
     val createClassOf = helper("createClassOf")
+    val getClassOf = helper("getClassOf")
     val arrayTypeData = helper("arrayTypeData")
     val getComponentType = helper("getComponentType")
+    val anyGetClass = helper("anyGetClass")
   }
 
   final case class WasmFieldName private (override private[wasm4s] val name: String)

--- a/wasm/src/main/scala/wasm4s/Types.scala
+++ b/wasm/src/main/scala/wasm4s/Types.scala
@@ -74,5 +74,6 @@ object Types {
     }
 
     val ObjectType = Type(WasmStructTypeName(IRNames.ObjectClass))
+    val ClassType = Type(WasmStructTypeName(IRNames.ClassClass))
   }
 }

--- a/wasm/src/main/scala/wasm4s/Wasm.scala
+++ b/wasm/src/main/scala/wasm4s/Wasm.scala
@@ -106,6 +106,18 @@ object WasmStructField {
   )
 }
 
+final case class WasmElement(typ: WasmType, init: List[WasmExpr], mode: WasmElement.Mode)
+
+object WasmElement {
+  sealed abstract class Mode
+
+  object Mode {
+    case object Passive extends Mode
+    // final case class Active(table: WasmImmediate.TableIdx, offset: WasmExpr) extends Mode
+    case object Declarative extends Mode
+  }
+}
+
 /** @see
   *   https://webassembly.github.io/spec/core/syntax/modules.html#modules
   */
@@ -123,8 +135,8 @@ class WasmModule(
     // val memories: List[WasmMemory] = Nil,
     private val _globals: mutable.ListBuffer[WasmGlobal] = new mutable.ListBuffer(),
     private val _exports: mutable.ListBuffer[WasmExport[_]] = new mutable.ListBuffer(),
-    private var _startFunction: Option[WasmFunctionName] = None
-    // val elements: List[WasmElement] = Nil,
+    private var _startFunction: Option[WasmFunctionName] = None,
+    private val _elements: mutable.ListBuffer[WasmElement] = new mutable.ListBuffer()
     // val tags: List[WasmTag] = Nil,
     // val startFunction: WasmFunction = null,
     // val data: List[WasmData] = Nil,
@@ -137,6 +149,7 @@ class WasmModule(
   def addGlobal(typ: WasmGlobal): Unit = _globals.addOne(typ)
   def addExport(exprt: WasmExport[_]) = _exports.addOne(exprt)
   def setStartFunction(startFunction: WasmFunctionName): Unit = _startFunction = Some(startFunction)
+  def addElement(element: WasmElement): Unit = _elements.addOne(element)
 
   def functionTypes = _functionTypes.toList
   def recGroupTypes = WasmModule.tsort(_recGroupTypes.toList)
@@ -146,6 +159,7 @@ class WasmModule(
   def globals = _globals.toList
   def exports = _exports.toList
   def startFunction: Option[WasmFunctionName] = _startFunction
+  def elements: List[WasmElement] = _elements.toList
 }
 
 object WasmModule {

--- a/wasm/src/main/scala/wasm4s/Wasm.scala
+++ b/wasm/src/main/scala/wasm4s/Wasm.scala
@@ -79,6 +79,53 @@ case class WasmStructType(
     fields: List[WasmStructField],
     superType: Option[WasmTypeName]
 ) extends WasmGCTypeDefinition
+object WasmStructType {
+  /** Run-time type data of a `TypeRef`.
+   *  Support for `j.l.Class` methods and other reflective operations.
+   *
+   *  @see [[Names.WasmFieldName.typeData]], which contains documentation of
+   *    what is in each field.
+   */
+  val typeData: WasmStructType = WasmStructType(
+    WasmTypeName.WasmStructTypeName.typeData,
+    List(
+      WasmStructField(
+        WasmFieldName.typeData.nameData,
+        WasmRefNullType(WasmHeapType.Type(WasmArrayTypeName.u16Array)),
+        isMutable = false
+      ),
+      WasmStructField(
+        WasmFieldName.typeData.kind,
+        WasmInt32,
+        isMutable = false
+      ),
+      WasmStructField(
+        WasmFieldName.typeData.componentType,
+        WasmRefNullType(WasmHeapType.Type(WasmTypeName.WasmStructTypeName.typeData)),
+        isMutable = false
+      ),
+      WasmStructField(
+        WasmFieldName.typeData.name,
+        WasmAnyRef,
+        isMutable = true
+      ),
+      WasmStructField(
+        WasmFieldName.typeData.classOfValue,
+        WasmRefNullType(WasmHeapType.ClassType),
+        isMutable = true
+      ),
+      WasmStructField(
+        WasmFieldName.typeData.arrayOf,
+        WasmRefNullType(WasmHeapType.Type(WasmTypeName.WasmStructTypeName.typeData)),
+        isMutable = true
+      )
+    ),
+    None
+  )
+
+  // The number of fields of typeData, after which we find the vtable entries
+  val typeDataFieldCount = typeData.fields.size
+}
 
 case class WasmArrayType(
     name: WasmTypeName,
@@ -90,6 +137,12 @@ object WasmArrayType {
   val itables = WasmArrayType(
     WasmArrayTypeName.itables,
     WasmStructField(WasmFieldName.itable, WasmRefType(WasmHeapType.Simple.Struct), false)
+  )
+
+  /** array u16 */
+  val u16Array = WasmArrayType(
+    WasmArrayTypeName.u16Array,
+    WasmStructField(WasmFieldName.u16Array, WasmInt16, false)
   )
 }
 
@@ -153,7 +206,7 @@ class WasmModule(
 
   def functionTypes = _functionTypes.toList
   def recGroupTypes = WasmModule.tsort(_recGroupTypes.toList)
-  def arrayTypes = List(WasmArrayType.itables)
+  def arrayTypes = List(WasmArrayType.itables, WasmArrayType.u16Array)
   def imports = _imports.toList
   def definedFunctions = _definedFunctions.toList
   def globals = _globals.toList

--- a/wasm/src/main/scala/wasm4s/WasmContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmContext.scala
@@ -154,6 +154,11 @@ trait FunctionTypeWriterWasmContext extends ReadOnlyWasmContext { this: WasmCont
     }
   }
 
+  def getConstantStringInstr(str: String): WasmInstr = {
+    val globalName = addConstantStringGlobal(str)
+    WasmInstr.GLOBAL_GET(WasmImmediate.GlobalIdx(globalName))
+  }
+
   def refFuncWithDeclaration(name: WasmFunctionName): WasmInstr.REF_FUNC = {
     addFuncDeclaration(name)
     WasmInstr.REF_FUNC(WasmImmediate.FuncIdx(name))
@@ -195,6 +200,8 @@ class WasmContext(val module: WasmModule) extends FunctionTypeWriterWasmContext 
     module.addImport(WasmImport(name.className, name.methodName, WasmImportDesc.Func(name, typ)))
   }
 
+  addGCType(WasmStructType.typeData)
+
   addHelperImport(WasmFunctionName.is, List(WasmAnyRef, WasmAnyRef), List(WasmInt32))
 
   addHelperImport(WasmFunctionName.undef, List(), List(WasmRefType.any))
@@ -214,6 +221,12 @@ class WasmContext(val module: WasmModule) extends FunctionTypeWriterWasmContext 
       addHelperImport(WasmFunctionName.typeTest(primRef), List(WasmAnyRef), List(WasmInt32))
     }
   }
+
+  addHelperImport(
+    WasmFunctionName.closure,
+    List(WasmRefType(WasmHeapType.Simple.Func), WasmAnyRef),
+    List(WasmRefType.any)
+  )
 
   addHelperImport(WasmFunctionName.emptyString, List(), List(WasmRefType.any))
   addHelperImport(WasmFunctionName.stringLength, List(WasmRefType.any), List(WasmInt32))

--- a/wasm/src/main/scala/wasm4s/WasmContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmContext.scala
@@ -244,6 +244,7 @@ class WasmContext(val module: WasmModule) extends FunctionTypeWriterWasmContext 
   )
   addHelperImport(WasmFunctionName.isString, List(WasmAnyRef), List(WasmInt32))
 
+  addHelperImport(WasmFunctionName.jsValueType, List(WasmRefType.any), List(WasmInt32))
   addHelperImport(WasmFunctionName.jsValueHashCode, List(WasmRefType.any), List(WasmInt32))
 
   addHelperImport(WasmFunctionName.jsGlobalRefGet, List(WasmRefType.any), List(WasmAnyRef))

--- a/wasm/src/main/scala/wasm4s/WasmFunctionContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmFunctionContext.scala
@@ -4,46 +4,208 @@ import scala.collection.mutable
 
 import org.scalajs.ir.{Names => IRNames}
 import org.scalajs.ir.{Types => IRTypes}
+import org.scalajs.ir.{Trees => IRTrees}
 
-import Names.WasmLocalName
+import wasm.wasm4s.Names._
+import wasm.wasm4s.Types.WasmType
+import wasm.wasm4s.WasmImmediate.{BlockType, LabelIdx, LocalIdx}
+import wasm.wasm4s.WasmInstr._
 
-class WasmFunctionContext private (private val _receiver: Option[WasmLocal]) {
+import wasm.ir2wasm.TypeTransformer
+
+class WasmFunctionContext private (
+  ctx: WasmContext,
+  val functionName: WasmFunctionName,
+  _receiver: Option[WasmLocal],
+  _params: List[WasmLocal],
+  _resultTypes: List[WasmType]
+) {
   private var cnt = 0
   private var labelIdx = 0
 
   val locals = new WasmSymbolTable[WasmLocalName, WasmLocal]()
-  def receiver = _receiver.getOrElse(throw new Error("Can access to the receiver in this context."))
+
+  private val _receiverAndParams = _receiver.toList ::: _params
+
+  _receiverAndParams.foreach(locals.define(_))
+
+  def receiver: WasmLocal =
+    _receiver.getOrElse(throw new Error("Cannot access to the receiver in this context."))
+
+  def paramIndices: List[LocalIdx] = _params.map(p => LocalIdx(p.name))
 
   private val registeredLabels =
-    mutable.AnyRefMap.empty[IRNames.LabelName, (WasmImmediate.LabelIdx, IRTypes.Type)]
+    mutable.AnyRefMap.empty[IRNames.LabelName, (LabelIdx, IRTypes.Type)]
 
-  def genLabel(): WasmImmediate.LabelIdx = {
-    val label = WasmImmediate.LabelIdx(labelIdx)
+  /** The instructions buffer; publicly mutable on purpose. */
+  val instrs: mutable.ListBuffer[WasmInstr] = mutable.ListBuffer.empty
+
+  def genLabel(): LabelIdx = {
+    val label = LabelIdx(labelIdx)
     labelIdx += 1
     label
   }
 
-  def registerLabel(irLabelName: IRNames.LabelName, expectedType: IRTypes.Type): WasmImmediate.LabelIdx = {
+  def registerLabel(irLabelName: IRNames.LabelName, expectedType: IRTypes.Type): LabelIdx = {
     val label = genLabel()
     registeredLabels(irLabelName) = (label, expectedType)
     label
   }
 
-  def getLabelFor(irLabelName: IRNames.LabelName): (WasmImmediate.LabelIdx, IRTypes.Type) = {
+  def getLabelFor(irLabelName: IRNames.LabelName): (LabelIdx, IRTypes.Type) = {
     registeredLabels.getOrElse(irLabelName, {
       throw new IllegalArgumentException(s"Unknown label ${irLabelName.nameString}")
     })
   }
+
+  def addLocal(name: WasmLocalName, typ: WasmType): LocalIdx = {
+    val local = WasmLocal(name, typ, isParameter = false)
+    locals.define(local)
+    LocalIdx(name)
+  }
+
+  def addLocal(name: String, typ: WasmType): LocalIdx =
+    addLocal(WasmLocalName(name), typ)
+
+  def addLocal(name: IRNames.LocalName, typ: WasmType): LocalIdx =
+    addLocal(WasmLocalName.fromIR(name), typ)
 
   def genSyntheticLocalName(): WasmLocalName = {
     val name = WasmLocalName.synthetic(cnt)
     cnt += 1
     name
   }
+
+  def addSyntheticLocal(typ: WasmType): LocalIdx =
+    addLocal(genSyntheticLocalName(), typ)
+
+  // Helpers to build structured control flow
+
+  def ifThenElse(blockType: BlockType)(thenp: => Unit)(elsep: => Unit): Unit = {
+    instrs += IF(blockType)
+    thenp
+    instrs += ELSE
+    elsep
+    instrs += END
+  }
+
+  def ifThenElse(resultType: WasmType)(thenp: => Unit)(elsep: => Unit): Unit =
+    ifThenElse(BlockType.ValueType(resultType))(thenp)(elsep)
+
+  def ifThenElse()(thenp: => Unit)(elsep: => Unit): Unit =
+    ifThenElse(BlockType.ValueType())(thenp)(elsep)
+
+  def ifThen(blockType: BlockType)(thenp: => Unit): Unit = {
+    instrs += IF(blockType)
+    thenp
+    instrs += END
+  }
+
+  def ifThen()(thenp: => Unit): Unit =
+    ifThen(BlockType.ValueType())(thenp)
+
+  def block[A](blockType: BlockType)(body: LabelIdx => A): A = {
+    val label = genLabel()
+    instrs += BLOCK(blockType, Some(label))
+    val result = body(label)
+    instrs += END
+    result
+  }
+
+  def block[A](resultType: WasmType)(body: LabelIdx => A): A =
+    block(BlockType.ValueType(resultType))(body)
+
+  def block[A]()(body: LabelIdx => A): A =
+    block(BlockType.ValueType())(body)
+
+  def block[A](sig: WasmFunctionSignature)(body: LabelIdx => A): A =
+    block(BlockType.FunctionType(ctx.addFunctionType(sig)))(body)
+
+  def block[A](resultTypes: List[WasmType])(body: LabelIdx => A): A = {
+    resultTypes match {
+      case Nil           => block()(body)
+      case single :: Nil => block(single)(body)
+      case _             => block(WasmFunctionSignature(Nil, resultTypes))(body)
+    }
+  }
+
+  def loop[A](blockType: BlockType)(body: LabelIdx => A): A = {
+    val label = genLabel()
+    instrs += LOOP(blockType, Some(label))
+    val result = body(label)
+    instrs += END
+    result
+  }
+
+  def loop[A](resultType: WasmType)(body: LabelIdx => A): A =
+    loop(BlockType.ValueType(resultType))(body)
+
+  def loop[A]()(body: LabelIdx => A): A =
+    loop(BlockType.ValueType())(body)
+
+  def loop[A](sig: WasmFunctionSignature)(body: LabelIdx => A): A =
+    loop(BlockType.FunctionType(ctx.addFunctionType(sig)))(body)
+
+  def loop[A](resultTypes: List[WasmType])(body: LabelIdx => A): A = {
+    resultTypes match {
+      case Nil           => loop()(body)
+      case single :: Nil => loop(single)(body)
+      case _             => loop(WasmFunctionSignature(Nil, resultTypes))(body)
+    }
+  }
+
+  // Final result
+
+  def buildAndAddToContext(): WasmFunction = {
+    val sig = WasmFunctionSignature(_receiverAndParams.map(_.typ), _resultTypes)
+    val typeName = ctx.addFunctionType(sig)
+    val functionType = WasmFunctionType(typeName, sig)
+
+    val expr = WasmExpr(instrs.toList)
+
+    val func = WasmFunction(functionName, functionType, locals.all, expr)
+    ctx.addFunction(func)
+    func
+  }
 }
 
 object WasmFunctionContext {
-  def apply(): WasmFunctionContext = new WasmFunctionContext(None)
-  def apply(receiver: WasmLocal): WasmFunctionContext = new WasmFunctionContext(Some(receiver))
-  def apply(receiver: Option[WasmLocal]): WasmFunctionContext = new WasmFunctionContext(receiver)
+  def apply(
+    name: WasmFunctionName,
+    receiver: Option[WasmLocal],
+    params: List[WasmLocal],
+    resultTypes: List[WasmType]
+  )(implicit ctx: WasmContext): WasmFunctionContext = {
+    new WasmFunctionContext(ctx, name, receiver, params, resultTypes)
+  }
+
+  def apply(
+    name: WasmFunctionName,
+    receiverTyp: Option[WasmType],
+    paramDefs: List[IRTrees.ParamDef],
+    resultType: IRTypes.Type
+  )(implicit ctx: WasmContext): WasmFunctionContext = {
+    val receiver = receiverTyp.map { typ =>
+      WasmLocal(WasmLocalName.receiver, typ, isParameter = true)
+    }
+    val params = paramDefs.map { paramDef =>
+      WasmLocal(
+        WasmLocalName.fromIR(paramDef.name.name),
+        TypeTransformer.transformType(paramDef.ptpe),
+        isParameter = true
+      )
+    }
+    apply(name, receiver, params, TypeTransformer.transformResultType(resultType))
+  }
+
+  def apply(
+    name: WasmFunctionName,
+    params: List[(String, WasmType)],
+    resultTypes: List[WasmType]
+  )(implicit ctx: WasmContext): WasmFunctionContext = {
+    val paramLocals = params.map { param =>
+      WasmLocal(WasmLocalName.fromStr(param._1), param._2, isParameter = true)
+    }
+    apply(name, receiver = None, paramLocals, resultTypes)
+  }
 }


### PR DESCRIPTION
Including elementary support of methods of `java.lang.Class`.

We implement this in a way that is similar to the JavaScript back-end: we have an internal `typeData` structure, which contains the raw metadata that will be needed by a `java.lang.Class` instance. It also contains a lazily evaluated pointer to the unique `java.lang.Class` and the `typeData` of an array of that type. If we need the `typeData` of a multi-dimensional array, we follow the chain of `arrayOf` pointers.

The name is initially stored as an `(array u16)` so that it can be initialized as a constant expression in globals. The `string` value is lazily initialized from that raw data the first time it is requested.

This machinery requires quite a bit of run-time helper functions. These are hard-coded in `HelperFunctions.scala`. Again, this is similar to the JS back-end, which defines a bunch of helper JS functions in its `CoreJSLib.scala`.

The `typeData` of classes that have a `vtable` are inserted into the `vtable` itself, making the latter a subtype of `typeData`. This is used for the support of `GetClass`: we fetch the `vtable` field of the object as the `typeData` from which to extract the `java.lang.Class` instance. The `typeData` of other classes are stored as independent globals.