### PR TITLE
Take inherited fields into account.

### DIFF
--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -14,6 +14,7 @@ object TestSuites {
     TestSuite("testsuite.core.HijackedClassesDispatchTest"),
     TestSuite("testsuite.core.HijackedClassesMonoTest"),
     TestSuite("testsuite.core.HijackedClassesUpcastTest"),
+    TestSuite("testsuite.core.StaticMethodTest"),
     TestSuite("testsuite.core.ToStringTest")
   )
 }

--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -9,6 +9,7 @@ object TestSuites {
     TestSuite("testsuite.core.InterfaceCall"),
     TestSuite("testsuite.core.AsInstanceOfTest"),
     TestSuite("testsuite.core.ClassOfTest"),
+    TestSuite("testsuite.core.FieldsTest"),
     TestSuite("testsuite.core.GetClassTest"),
     TestSuite("testsuite.core.JSInteropTest"),
     TestSuite("testsuite.core.HijackedClassesDispatchTest"),

--- a/run.mjs
+++ b/run.mjs
@@ -1,5 +1,5 @@
 import { load } from "./loader.mjs";
 
 const { test } = await load("./target/output.wasm");
-const o = test();
+const o = test(7);
 console.log(o);

--- a/sample/src/main/scala/Sample.scala
+++ b/sample/src/main/scala/Sample.scala
@@ -12,8 +12,7 @@ import scala.scalajs.js.annotation._
 //
 object Main {
   @JSExportTopLevel("test")
-  def test() = {
-    val i = 4
+  def test(i: Int): Boolean = {
     val loopFib = fib(new LoopFib {}, i)
     val recFib = fib(new RecFib {}, i)
     val tailrecFib = fib(new TailRecFib {}, i)

--- a/test-suite/src/main/scala/testsuite/core/FieldsTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/FieldsTest.scala
@@ -1,0 +1,29 @@
+package testsuite.core
+
+import testsuite.Assert.ok
+
+object FieldsTest {
+  def main(): Unit = {
+    val parent = new Parent(5)
+    ok(parent.x == 5)
+    ok(parent.getX == 5)
+
+    val child = new Child(6, "foo")
+    ok(child.x == 6)
+    ok(child.getX == 6)
+    ok(child.foo() == 3)
+
+    val child2 = new Child(-6, "foo")
+    ok(child2.x == -6)
+    ok(child2.getX == -6)
+    ok(child2.foo() == -3)
+  }
+
+  class Parent(val x: Int) {
+    def getX: Int = x
+  }
+
+  class Child(x2: Int, y: String) extends Parent(x2) {
+    def foo(): Int = if (x >= 0) y.length() else -y.length()
+  }
+}

--- a/test-suite/src/main/scala/testsuite/core/StaticMethodTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/StaticMethodTest.scala
@@ -1,0 +1,10 @@
+package testsuite.core
+
+import testsuite.Assert.ok
+
+object StaticMethodTest {
+  def main(): Unit = {
+    ok(java.lang.Integer.sum(5, 65) == 70)
+    ok(java.lang.Integer.reverseBytes(0x01020304) == 0x04030201)
+  }
+}

--- a/wasm/src/main/scala/Compiler.scala
+++ b/wasm/src/main/scala/Compiler.scala
@@ -63,8 +63,14 @@ object Compiler {
     } yield {
       val onlyModule = moduleSet.modules.head
 
-      // Sort for stability
-      val sortedClasses = onlyModule.classDefs.sortBy(_.className)
+      /* Sort by ancestor count so that superclasses always appear before
+       * subclasses, then tie-break by name for stability.
+       */
+      val sortedClasses = onlyModule.classDefs.sortWith { (a, b) =>
+        val cmp = a.ancestors.sizeCompare(b.ancestors)
+        if (cmp != 0) cmp < 0
+        else a.className.compareTo(b.className) < 0
+      }
 
       sortedClasses.foreach(showLinkedClass(_))
 

--- a/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
+++ b/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
@@ -327,7 +327,11 @@ object HelperFunctions {
     // TODO: "isInstance", "isAssignableFrom", "checkCast", "newArrayOfThisClass"
 
     // Call java.lang.Class::<init>(dataObject)
-    instrs += CALL(FuncIdx(WasmFunctionName(IRNames.ClassClass, SpecialNames.ClassCtor)))
+    instrs += CALL(FuncIdx(WasmFunctionName(
+      IRTrees.MemberNamespace.Constructor,
+      IRNames.ClassClass,
+      SpecialNames.ClassCtor
+    )))
 
     // typeData.classOf := classInstance
     instrs += LOCAL_GET(typeDataParam)

--- a/wasm/src/main/scala/ir2wasm/Preprocessor.scala
+++ b/wasm/src/main/scala/ir2wasm/Preprocessor.scala
@@ -47,7 +47,7 @@ object Preprocessor {
       method: IRTrees.MethodDef
   ): WasmFunctionInfo = {
     WasmFunctionInfo(
-      Names.WasmFunctionName(clazz.name.name, method.name.name),
+      Names.WasmFunctionName(method.flags.namespace, clazz.name.name, method.name.name),
       method.args.map(_.ptpe),
       method.resultType,
       isAbstract = method.body.isEmpty

--- a/wasm/src/main/scala/ir2wasm/Preprocessor.scala
+++ b/wasm/src/main/scala/ir2wasm/Preprocessor.scala
@@ -22,9 +22,9 @@ object Preprocessor {
   }
 
   private def preprocess(clazz: LinkedClass)(implicit ctx: WasmContext): Unit = {
-    val infos = clazz.methods.filterNot(_.flags.namespace.isConstructor).map { method =>
-      makeWasmFunctionInfo(clazz, method)
-    }
+    val infos = clazz.methods
+      .filter(_.flags.namespace == IRTrees.MemberNamespace.Public)
+      .map(method => makeWasmFunctionInfo(clazz, method))
 
     ctx.putClassInfo(
       clazz.name.name,

--- a/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
@@ -441,18 +441,20 @@ class WasmBuilder {
     // Otherwise, vtable can't be a subtype of the supertype's subtype
     // Constructor can use the exact type because it won't be registered to vtables.
     val receiverTyp =
-      if (clazz.kind == ClassKind.HijackedClass)
-        transformType(IRTypes.BoxedClassToPrimType(clazz.name.name))
+      if (method.flags.namespace.isStatic)
+        None
+      else if (clazz.kind == ClassKind.HijackedClass)
+        Some(transformType(IRTypes.BoxedClassToPrimType(clazz.name.name)))
       else if (method.flags.namespace.isConstructor)
-        WasmRefNullType(WasmHeapType.Type(WasmTypeName.WasmStructTypeName(clazz.name.name)))
+        Some(WasmRefNullType(WasmHeapType.Type(WasmTypeName.WasmStructTypeName(clazz.name.name))))
       else
-        WasmRefType.any
+        Some(WasmRefType.any)
 
     // Prepare for function context, set receiver and parameters
     implicit val fctx = WasmFunctionContext(
       Some(clazz.className),
       functionName,
-      Some(receiverTyp),
+      receiverTyp,
       method.args,
       method.resultType
     )

--- a/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
@@ -230,7 +230,13 @@ class WasmBuilder {
       .getOrElse(throw new Error(s"Module class should have a constructor, ${clazz.name}"))
     val typeName = WasmTypeName.WasmStructTypeName(clazz.name.name)
     val globalInstanceName = WasmGlobalName.WasmModuleInstanceName.fromIR(clazz.name.name)
-    val ctorName = WasmFunctionName(clazz.name.name, ctor.name.name)
+
+    val ctorName = WasmFunctionName(
+      ctor.flags.namespace,
+      clazz.name.name,
+      ctor.name.name
+    )
+
     val body = List(
       // global.get $module_name
       // ref.if_null
@@ -355,7 +361,7 @@ class WasmBuilder {
       Names.WasmTypeName.WasmITableTypeName(className),
       classInfo.methods.map { m =>
         WasmStructField(
-          Names.WasmFieldName(m.name.methodName),
+          Names.WasmFieldName(m.name.simpleName),
           WasmRefNullType(WasmHeapType.Func(m.toWasmFunctionType().name)),
           isMutable = false
         )
@@ -425,7 +431,11 @@ class WasmBuilder {
       clazz: LinkedClass,
       method: IRTrees.MethodDef
   )(implicit ctx: WasmContext): WasmFunction = {
-    val functionName = Names.WasmFunctionName(clazz.name.name, method.name.name)
+    val functionName = Names.WasmFunctionName(
+      method.flags.namespace,
+      clazz.name.name,
+      method.name.name
+    )
 
     // Receiver type for non-constructor methods needs to be `(ref any)` because params are invariant
     // Otherwise, vtable can't be a subtype of the supertype's subtype

--- a/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
@@ -220,7 +220,7 @@ private class WasmExpressionBuilder private (
       case sel: IRTrees.Select =>
         val className = sel.field.name.className
         val fieldName = WasmFieldName(sel.field.name)
-        val idx = ctx.getClassInfo(className).getFieldIdx(fieldName)
+        val idx = ctx.getClassInfo(className).getFieldIdx(sel.field.name)
 
         // For Select, the receiver can never be a hijacked class, so we can use genTreeAuto
         genTreeAuto(sel.qualifier)
@@ -231,7 +231,7 @@ private class WasmExpressionBuilder private (
       case sel: IRTrees.SelectStatic => // OK?
         val className = sel.field.name.className
         val fieldName = WasmFieldName(sel.field.name)
-        val idx = ctx.getClassInfo(className).getFieldIdx(fieldName)
+        val idx = ctx.getClassInfo(className).getFieldIdx(sel.field.name)
         instrs += GLOBAL_GET(
           GlobalIdx(Names.WasmGlobalName.WasmModuleInstanceName.fromIR(className))
         )
@@ -675,7 +675,7 @@ private class WasmExpressionBuilder private (
   private def genSelect(sel: IRTrees.Select): IRTypes.Type = {
     val className = sel.field.name.className
     val fieldName = WasmFieldName(sel.field.name)
-    val idx = ctx.getClassInfo(className).getFieldIdx(fieldName)
+    val idx = ctx.getClassInfo(className).getFieldIdx(sel.field.name)
 
     // For Select, the receiver can never be a hijacked class, so we can use genTreeAuto
     genTreeAuto(sel.qualifier)

--- a/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
@@ -337,7 +337,11 @@ private class WasmExpressionBuilder private (
      * After this code gen, the stack contains the result.
      */
     def genHijackedClassCall(hijackedClass: IRNames.ClassName): Unit = {
-      val funcName = Names.WasmFunctionName(hijackedClass, t.method.name)
+      val funcName = Names.WasmFunctionName(
+        IRTrees.MemberNamespace.Public,
+        hijackedClass,
+        t.method.name
+      )
       instrs += CALL(FuncIdx(funcName))
     }
 
@@ -522,7 +526,11 @@ private class WasmExpressionBuilder private (
 
       val (methodIdx, info) = ctx
         .calculateVtableType(receiverClassName)
-        .resolveWithIdx(WasmFunctionName(receiverClassName, methodName))
+        .resolveWithIdx(WasmFunctionName(
+          IRTrees.MemberNamespace.Public,
+          receiverClassName,
+          methodName
+        ))
 
       // // push args to the stacks
       // local.get $this ;; for accessing funcref
@@ -582,7 +590,8 @@ private class WasmExpressionBuilder private (
         }
 
         genArgs(t.args, t.method.name)
-        val funcName = Names.WasmFunctionName(t.className, t.method.name)
+        val namespace = IRTrees.MemberNamespace.forNonStaticCall(t.flags)
+        val funcName = Names.WasmFunctionName(namespace, t.className, t.method.name)
         instrs += CALL(FuncIdx(funcName))
         if (t.tpe == IRTypes.NothingType)
           instrs += UNREACHABLE
@@ -1328,7 +1337,11 @@ private class WasmExpressionBuilder private (
     instrs += CALL(FuncIdx(WasmFunctionName.newDefault(n.className)))
     instrs += LOCAL_TEE(LocalIdx(localInstance.name))
     genArgs(n.args, n.ctor.name)
-    instrs += CALL(FuncIdx(WasmFunctionName(n.className, n.ctor.name)))
+    instrs += CALL(FuncIdx(WasmFunctionName(
+      IRTrees.MemberNamespace.Constructor,
+      n.className,
+      n.ctor.name
+    )))
     instrs += LOCAL_GET(LocalIdx(localInstance.name))
     n.tpe
   }

--- a/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
@@ -108,6 +108,7 @@ private class WasmExpressionBuilder private (
       case t: IRTrees.This             => genThis(t)
       case t: IRTrees.ApplyStatically  => genApplyStatically(t)
       case t: IRTrees.Apply            => genApply(t)
+      case t: IRTrees.ApplyStatic      => genApplyStatic(t)
       case t: IRTrees.IsInstanceOf     => genIsInstanceOf(t)
       case t: IRTrees.AsInstanceOf     => genAsInstanceOf(t)
       case t: IRTrees.GetClass         => genGetClass(t)
@@ -597,6 +598,16 @@ private class WasmExpressionBuilder private (
           instrs += UNREACHABLE
         t.tpe
     }
+  }
+
+  private def genApplyStatic(tree: IRTrees.ApplyStatic): IRTypes.Type = {
+    genArgs(tree.args, tree.method.name)
+    val namespace = IRTrees.MemberNamespace.forStaticCall(tree.flags)
+    val funcName = Names.WasmFunctionName(namespace, tree.className, tree.method.name)
+    instrs += CALL(FuncIdx(funcName))
+    if (tree.tpe == IRTypes.NothingType)
+      instrs += UNREACHABLE
+    tree.tpe
   }
 
   private def genArgs(args: List[IRTrees.Tree], methodName: IRNames.MethodName): Unit = {

--- a/wasm/src/main/scala/wasm4s/Names.scala
+++ b/wasm/src/main/scala/wasm4s/Names.scala
@@ -103,7 +103,9 @@ object Names {
   object WasmFunctionName {
     def apply(clazz: IRNames.ClassName, method: IRNames.MethodName): WasmFunctionName =
       new WasmFunctionName(clazz.nameString, method.nameString)
-    def apply(lit: IRTrees.StringLiteral): WasmFunctionName = new WasmFunctionName(lit.value, "")
+
+    def forExport(exportedName: String): WasmFunctionName =
+      new WasmFunctionName(exportedName, "")
 
     // Adding prefix __ to avoid name clashes with user code.
     // It should be safe not to add prefix to the method name

--- a/wasm/src/main/scala/wasm4s/WasmContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmContext.scala
@@ -306,15 +306,11 @@ class WasmContext(val module: WasmModule) extends FunctionTypeWriterWasmContext 
         case ModuleInitializerImpl.MainMethodWithArgs(className, encodedMainMethodName, args) =>
           () // TODO: but we don't use args yet in scala-wasm
         case ModuleInitializerImpl.VoidMainMethod(className, encodedMainMethodName) =>
-          val name = className.withSuffix("$")
-          instrs +=
-            WasmInstr.CALL(WasmImmediate.FuncIdx(Names.WasmFunctionName.loadModule(name)))
-          instrs += WasmInstr.REF_AS_NOT_NULL
           instrs +=
             WasmInstr.CALL(
               WasmImmediate.FuncIdx(WasmFunctionName(
-                IRTrees.MemberNamespace.Public,
-                name,
+                IRTrees.MemberNamespace.PublicStatic,
+                className,
                 encodedMainMethodName
               ))
             )


### PR DESCRIPTION
In `LinkedClass`es, the `fields` only list fields declared directly in the given class. When allocating Wasm structs and computing indices, we must take inherited fields into account as well.

Based on #21.