### PR TITLE
Supply missing step in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Usage
 
-- first, `npm install jszip`
+- first, `npm install`
 - then `sample/run` to compile `sample/src/main/scala/Sample.scala`.
   - prints the WebAssembly Text Format (WAT) (Stack IR form) to the console, for debugging
   - writes the binary format (WASM) to `target/output.wasm`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ### Usage
 
-- `sample/run` to compile `sample/src/main/scala/Sample.scala`.
+- first, `npm install jszip`
+- then `sample/run` to compile `sample/src/main/scala/Sample.scala`.
   - prints the WebAssembly Text Format (WAT) (Stack IR form) to the console, for debugging
   - writes the binary format (WASM) to `target/output.wasm`
 


### PR DESCRIPTION
I have no idea what I'm doing, but, I found this to be necessary before I could `sample/run`