### PR TITLE
Fix #32: Implement exception handling.

### DIFF
--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -21,6 +21,7 @@ object TestSuites {
     TestSuite("testsuite.core.HijackedClassesUpcastTest"),
     TestSuite("testsuite.core.StaticMethodTest"),
     TestSuite("testsuite.core.ThrowablesTest"),
-    TestSuite("testsuite.core.ToStringTest")
+    TestSuite("testsuite.core.ToStringTest"),
+    TestSuite("testsuite.core.WrapUnwrapThrowableTest")
   )
 }

--- a/test-suite/src/main/scala/testsuite/Assert.scala
+++ b/test-suite/src/main/scala/testsuite/Assert.scala
@@ -1,16 +1,6 @@
 package testsuite
 
-/** Temporary assertion method on Scala for Wasm. `ok` method generates `unreachable` if the given
-  * condition is false, trapping at runtime.
-  *
-  * While it's desirable to eventually utilize Scala's assertion, it's currently unavailable because
-  * we cannot compile Throwable to wasm yet, thus throw new (Throwable) is unusable. and making
-  * assert unavailable as well.
-  *
-  * Using JS's assert isn't feasible either; `console.assert` merely displays a message when
-  * assertion failure, and Node's assert module is unsupported for Wasm due to current
-  * unavailability of `JSImport` and module.
-  */
+/** Assertion helpers. */
 object Assert {
   def ok(cond: Boolean): Unit =
     if (!cond) fail()
@@ -19,5 +9,5 @@ object Assert {
     ok(expected.asInstanceOf[AnyRef] eq actual.asInstanceOf[AnyRef])
 
   def fail(): Unit =
-    null.toString() // Apply to Null should compile to unreachable
+    throw new AssertionError("assertion failed")
 }

--- a/test-suite/src/main/scala/testsuite/Assert.scala
+++ b/test-suite/src/main/scala/testsuite/Assert.scala
@@ -13,8 +13,11 @@ package testsuite
   */
 object Assert {
   def ok(cond: Boolean): Unit =
-    if (!cond) null.toString() // Apply to Null should compile to unreachable
+    if (!cond) fail()
 
   def assertSame(expected: Any, actual: Any): Unit =
     ok(expected.asInstanceOf[AnyRef] eq actual.asInstanceOf[AnyRef])
+
+  def fail(): Unit =
+    null.toString() // Apply to Null should compile to unreachable
 }

--- a/test-suite/src/main/scala/testsuite/core/WrapUnwrapThrowableTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/WrapUnwrapThrowableTest.scala
@@ -1,0 +1,46 @@
+package testsuite.core
+
+import scala.scalajs.js
+
+import testsuite.Assert.{assertSame, fail}
+
+object WrapUnwrapThrowableTest {
+  def main(): Unit = {
+    testWrapAsThrowable()
+    testUnwrapFromThrowable()
+  }
+
+  def testWrapAsThrowable(): Unit = {
+    // Wraps a js.Object
+    val obj = new js.Object
+    val e1 = js.special.wrapAsThrowable(obj)
+    e1 match {
+      case e1: js.JavaScriptException => assertSame(obj, e1.exception)
+      case _                          => fail()
+    }
+
+    // Wraps null
+    val e2 = js.special.wrapAsThrowable(null)
+    e2 match {
+      case e2: js.JavaScriptException => assertSame(null, e2.exception)
+      case _                          => fail()
+    }
+
+    // Does not wrap a Throwable
+    val th = new IllegalArgumentException
+    assertSame(th, js.special.wrapAsThrowable(th))
+
+    // Does not double-wrap
+    assertSame(e1, js.special.wrapAsThrowable(e1))
+  }
+
+  def testUnwrapFromThrowable(): Unit = {
+    // Unwraps a JavaScriptException
+    val obj = new js.Object
+    assertSame(obj, js.special.unwrapFromThrowable(new js.JavaScriptException(obj)))
+
+    // Does not unwrap a Throwable
+    val th = new IllegalArgumentException
+    assertSame(th, js.special.unwrapFromThrowable(th))
+  }
+}

--- a/testrun.html
+++ b/testrun.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Test run</title>
+  </head>
+  <body>
+    <p>Look at the console</p>
+    <script type="module" src="./run.mjs"></script>
+  </body>
+</html>

--- a/wasm/src/main/scala/converters/WasmBinaryWriter.scala
+++ b/wasm/src/main/scala/converters/WasmBinaryWriter.scala
@@ -341,6 +341,13 @@ final class WasmBinaryWriter(module: WasmModule) {
       case HeapType(value)       => writeHeapType(buf, value)
       case StructFieldIdx(value) => buf.u32(value)
 
+      case CatchClauseVector(clauses) =>
+        buf.vec(clauses) { clause =>
+          buf.byte(clause.opcode.toByte)
+          for (imm <- clause.immediates)
+            writeImmediate(buf, imm)
+        }
+
       case CastFlags(nullable1, nullable2) =>
         buf.byte(((if (nullable1) 1 else 0) | (if (nullable2) 2 else 0)).toByte)
     }

--- a/wasm/src/main/scala/converters/WasmTextWriter.scala
+++ b/wasm/src/main/scala/converters/WasmTextWriter.scala
@@ -300,8 +300,8 @@ class WasmTextWriter {
 
   private def writeInstr(instr: WasmInstr)(implicit b: WatBuilder): Unit = {
     instr match {
-      case END | ELSE | _: CATCH => b.deindent()
-      case _                     => ()
+      case END | ELSE => b.deindent()
+      case _          => ()
     }
     b.newLine()
     b.appendElement(instr.mnemonic)
@@ -333,8 +333,8 @@ class WasmTextWriter {
     }
 
     instr match {
-      case _: BLOCK | _: LOOP | _: IF | ELSE | _: CATCH | _: TRY => b.indent()
-      case _                                                     => ()
+      case _: BLOCK | _: LOOP | _: IF | ELSE => b.indent()
+      case _                                 => ()
     }
   }
 

--- a/wasm/src/main/scala/converters/WasmTextWriter.scala
+++ b/wasm/src/main/scala/converters/WasmTextWriter.scala
@@ -278,6 +278,14 @@ class WasmTextWriter {
         indices.map(i => "$" + i.value).mkString(" ")
       case WasmImmediate.TagIdx(name) =>
         name.show
+      case WasmImmediate.CatchClauseVector(clauses) =>
+        for (clause <- clauses) {
+          b.appendElement("(" + clause.mnemonic)
+          for (imm <- clause.immediates)
+            writeImmediate(imm, instr)
+          b.appendElement(")")
+        }
+        ""
       case i: WasmImmediate.CastFlags =>
         throw new UnsupportedOperationException(
           s"CastFlags $i must be handled directly in the instruction $instr"

--- a/wasm/src/main/scala/converters/WasmTextWriter.scala
+++ b/wasm/src/main/scala/converters/WasmTextWriter.scala
@@ -333,8 +333,8 @@ class WasmTextWriter {
     }
 
     instr match {
-      case _: BLOCK | _: LOOP | _: IF | ELSE => b.indent()
-      case _                                 => ()
+      case _: StructuredLabeledInstr | ELSE => b.indent()
+      case _                                => ()
     }
   }
 

--- a/wasm/src/main/scala/converters/WasmTextWriter.scala
+++ b/wasm/src/main/scala/converters/WasmTextWriter.scala
@@ -27,6 +27,7 @@ class WasmTextWriter {
         )
         module.imports.foreach(writeImport)
         module.definedFunctions.foreach(writeFunction)
+        module.tags.foreach(writeTag)
         module.globals.foreach(writeGlobal)
         module.exports.foreach(writeExport)
         module.startFunction.foreach(writeStart)
@@ -123,6 +124,13 @@ class WasmTextWriter {
                 writeSig(typ.params, typ.results)
               }
             )
+          case WasmImportDesc.Tag(id, typ) =>
+            b.sameLineList(
+              "tag", {
+                b.appendElement(id.show)
+                writeSig(typ.params, typ.results)
+              }
+            )
         }
       }
     )
@@ -169,6 +177,15 @@ class WasmTextWriter {
           nonParams.foreach(writeLocal)
         }
         f.body.instr.foreach(writeInstr)
+      }
+    )
+  }
+
+  private def writeTag(tag: WasmTag)(implicit b: WatBuilder): Unit = {
+    b.newLineList(
+      "tag", {
+        b.appendElement(tag.name.show)
+        b.sameLineListOne("type", tag.typ.show)
       }
     )
   }
@@ -259,6 +276,8 @@ class WasmTextWriter {
       case WasmImmediate.LabelIdx(i) => s"$$${i.toString}" // `loop 0` seems to be invalid
       case WasmImmediate.LabelIdxVector(indices) =>
         indices.map(i => "$" + i.value).mkString(" ")
+      case WasmImmediate.TagIdx(name) =>
+        name.show
       case i: WasmImmediate.CastFlags =>
         throw new UnsupportedOperationException(
           s"CastFlags $i must be handled directly in the instruction $instr"

--- a/wasm/src/main/scala/ir2wasm/LibraryPatches.scala
+++ b/wasm/src/main/scala/ir2wasm/LibraryPatches.scala
@@ -31,8 +31,13 @@ object LibraryPatches {
       }
     }
 
+    val leanerJSExceptionIRFile =
+      org.scalajs.linker.backend.emitter.PrivateLibHolder.files.find { irFile =>
+        IRFileImpl.fromIRFile(irFile).path.contains("JavaScriptException")
+      }.get
+
     derivedIRFiles.map { derived =>
-      derived.flatten ++ Seq(StackTraceIRFile) ++ irFiles
+      derived.flatten ++ Seq(StackTraceIRFile, leanerJSExceptionIRFile) ++ irFiles
     }
   }
 

--- a/wasm/src/main/scala/ir2wasm/SpecialNames.scala
+++ b/wasm/src/main/scala/ir2wasm/SpecialNames.scala
@@ -16,4 +16,9 @@ object SpecialNames {
 
   // The constructor of java.lang.Class
   val ClassCtor = MethodName.constructor(List(ClassRef(ObjectClass)))
+
+  // js.JavaScriptException, for WrapAsThrowable and UnwrapFromThrowable
+  val JSExceptionClass = ClassName("scala.scalajs.js.JavaScriptException")
+  val JSExceptionCtor = MethodName.constructor(List(ClassRef(ObjectClass)))
+  val JSExceptionField = FieldName(JSExceptionClass, SimpleFieldName("exception"))
 }

--- a/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
@@ -122,6 +122,7 @@ private class WasmExpressionBuilder private (
       case t: IRTrees.New                 => genNew(t)
       case t: IRTrees.If                  => genIf(t, expectedType)
       case t: IRTrees.While               => genWhile(t)
+      case t: IRTrees.Throw               => genThrow(t)
       case t: IRTrees.Debugger            => IRTypes.NoType // ignore
       case t: IRTrees.Skip                => IRTypes.NoType
       case t: IRTrees.IdentityHashCode    => genIdentityHashCode(t)
@@ -146,9 +147,6 @@ private class WasmExpressionBuilder private (
       case t: IRTrees.JSLinkingInfo        => genJSLinkingInfo(t)
       case t: IRTrees.Closure              => genClosure(t)
       case t: IRTrees.Clone                => genClone(t)
-      case _: IRTrees.Throw =>
-        instrs += UNREACHABLE
-        IRTypes.NothingType
 
       // array
       case t: IRTrees.ArrayLength => genArrayLength(t)
@@ -1326,6 +1324,13 @@ private class WasmExpressionBuilder private (
         }
         IRTypes.NoType
     }
+  }
+
+  private def genThrow(tree: IRTrees.Throw): IRTypes.Type = {
+    genTree(tree.expr, IRTypes.AnyType)
+    instrs += THROW(TagIdx(ctx.exceptionTagName))
+
+    IRTypes.NothingType
   }
 
   private def genBlock(t: IRTrees.Block, expectedType: IRTypes.Type): IRTypes.Type = {

--- a/wasm/src/main/scala/wasm4s/Defaults.scala
+++ b/wasm/src/main/scala/wasm4s/Defaults.scala
@@ -12,6 +12,7 @@ object Defaults {
     case WasmInt32                 => I32_CONST(I32(0))
     case WasmAnyRef                => REF_NULL(HeapType(WasmHeapType.Simple.Any))
     case WasmExternRef             => REF_NULL(HeapType(WasmHeapType.Simple.NoExtern))
+    case WasmExnRef                => REF_NULL(HeapType(WasmHeapType.Simple.NoExn))
     case WasmRefType(_)            => nonDefaultable(t)
     case WasmFloat32               => F32_CONST(F32(0))
     case WasmFuncRef               => REF_NULL(HeapType(WasmHeapType.Simple.Func))

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -339,7 +339,7 @@ object WasmImmediate {
   case class LabelIdxVector(val value: List[LabelIdx]) extends WasmImmediate
   case class TypeIdx(val value: WasmTypeName) extends WasmImmediate
   case class TableIdx(val value: Int) extends WasmImmediate
-  case class TagIdx(val value: Int) extends WasmImmediate
+  case class TagIdx(val value: WasmTagName) extends WasmImmediate
   case class LocalIdx(val value: WasmLocalName) extends WasmImmediate
   case class GlobalIdx(val value: WasmGlobalName) extends WasmImmediate
   case class HeapType(val value: WasmHeapType) extends WasmImmediate

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -204,12 +204,7 @@ object WasmInstr {
   case class CALL(i: FuncIdx) extends WasmInstr("call", 0x10, List(i))
   case class CALL_INDIRECT(i: TableIdx, t: TypeIdx)
       extends WasmInstr("call_indirect", 0x11, List(i, t))
-  case class TRY(i: BlockType) extends WasmInstr("try", 0x06, List(i))
-  case class CATCH(i: TagIdx) extends WasmInstr("catch", 0x07, List(i))
-  case object CATCH_ALL extends WasmInstr("catch_all", 0x19)
-  case class DELEGATE(i: LabelIdx) extends WasmInstr("delegate", 0x18, List(i))
   case class THROW(i: TagIdx) extends WasmInstr("throw", 0x08, List(i))
-  case class RETHROW(i: LabelIdx) extends WasmInstr("rethrow", 0x09)
 
   // Parametric instructions
   // https://webassembly.github.io/spec/core/syntax/instructions.html#parametric-instructions

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -205,6 +205,9 @@ object WasmInstr {
   case class CALL_INDIRECT(i: TableIdx, t: TypeIdx)
       extends WasmInstr("call_indirect", 0x11, List(i, t))
   case class THROW(i: TagIdx) extends WasmInstr("throw", 0x08, List(i))
+  case object THROW_REF extends WasmInstr("throw_ref", 0x0A)
+  case class TRY_TABLE(i: BlockType, cs: CatchClauseVector, label: Option[LabelIdx] = None)
+      extends StructuredLabeledInstr("try_table", 0x1F, List(i, cs))
 
   // Parametric instructions
   // https://webassembly.github.io/spec/core/syntax/instructions.html#parametric-instructions
@@ -338,11 +341,14 @@ object WasmImmediate {
   case class LocalIdx(val value: WasmLocalName) extends WasmImmediate
   case class GlobalIdx(val value: WasmGlobalName) extends WasmImmediate
   case class HeapType(val value: WasmHeapType) extends WasmImmediate
+
   case class StructFieldIdx(val value: Int) extends WasmImmediate
   object StructFieldIdx {
     val vtable = StructFieldIdx(0)
     val itables = StructFieldIdx(1)
   }
+
+  case class CatchClauseVector(val value: List[CatchClause]) extends WasmImmediate
 
   /** `castflags` for `br_on_cast` and `br_on_cast_fail`.
     *
@@ -350,4 +356,17 @@ object WasmImmediate {
     *   https://webassembly.github.io/gc/core/binary/instructions.html#control-instructions
     */
   case class CastFlags(nullable1: Boolean, nullable2: Boolean) extends WasmImmediate
+
+  sealed abstract class CatchClause(
+      val mnemonic: String,
+      val opcode: Int,
+      val immediates: List[WasmImmediate]
+  )
+
+  object CatchClause {
+    case class Catch(x: TagIdx, l: LabelIdx) extends CatchClause("catch", 0x00, List(x, l))
+    case class CatchRef(x: TagIdx, l: LabelIdx) extends CatchClause("catch_ref", 0x01, List(x, l))
+    case class CatchAll(l: LabelIdx) extends CatchClause("catch_all", 0x02, List(l))
+    case class CatchAllRef(l: LabelIdx) extends CatchClause("catch_all_ref", 0x03, List(l))
+  }
 }

--- a/wasm/src/main/scala/wasm4s/Names.scala
+++ b/wasm/src/main/scala/wasm4s/Names.scala
@@ -17,6 +17,7 @@ object Names {
         case _: WasmGlobalName.WasmGlobalConstantStringName => "str_const"
         case _: WasmFunctionName                            => "fun"
         case _: WasmFieldName                               => "field"
+        case _: WasmTagName                                 => "tag"
         case _: WasmExportName                              => "export"
         case _: WasmTypeName.WasmFunctionTypeName           => "ty"
         case _: WasmTypeName.WasmStructTypeName             => "struct"
@@ -383,6 +384,12 @@ object Names {
       def apply(ir: IRNames.ClassName) = new WasmITableTypeName(ir.nameString)
     }
 
+  }
+
+  final case class WasmTagName private (override private[wasm4s] val name: String)
+      extends WasmName(name)
+  object WasmTagName {
+    def fromStr(str: String): WasmTagName = new WasmTagName(str)
   }
 
   final case class WasmExportName private (override private[wasm4s] val name: String)

--- a/wasm/src/main/scala/wasm4s/Types.scala
+++ b/wasm/src/main/scala/wasm4s/Types.scala
@@ -35,6 +35,7 @@ object Types {
   // https://github.com/WebAssembly/gc/blob/main/proposals/gc/MVP.md#reference-types-1
   case object WasmFuncRef extends WasmType("funcref", 0x70)
   case object WasmExternRef extends WasmType("externref", 0x6F)
+  case object WasmExnRef extends WasmType("exnref", 0x69)
 
   /** shorthand for (ref null any) */
   case object WasmAnyRef extends WasmType("anyref", 0x6E)
@@ -73,9 +74,11 @@ object Types {
       object Any extends Simple("any", 0x6E)
       object Eq extends Simple("eq", 0x6D)
       object Array extends Simple("array", 0x6A)
+      object Exn extends Simple("exn", 0x69)
       object Struct extends Simple("struct", 0x6B)
       object None extends Simple("none", 0x71)
       object NoExtern extends Simple("noextern", 0x72)
+      object NoExn extends Simple("noexn", 0x74)
     }
 
     val ObjectType = Type(WasmStructTypeName(IRNames.ObjectClass))

--- a/wasm/src/main/scala/wasm4s/Types.scala
+++ b/wasm/src/main/scala/wasm4s/Types.scala
@@ -4,6 +4,8 @@ import org.scalajs.ir.{Names => IRNames}
 import Names._
 import Names.WasmTypeName._
 
+import wasm.ir2wasm.SpecialNames
+
 object Types {
   abstract sealed class WasmStorageType(
       private val name: String,
@@ -78,5 +80,7 @@ object Types {
 
     val ObjectType = Type(WasmStructTypeName(IRNames.ObjectClass))
     val ClassType = Type(WasmStructTypeName(IRNames.ClassClass))
+    val ThrowableType = Type(WasmStructTypeName(IRNames.ThrowableClass))
+    val JSExceptionType = Type(WasmStructTypeName(SpecialNames.JSExceptionClass))
   }
 }

--- a/wasm/src/main/scala/wasm4s/Wasm.scala
+++ b/wasm/src/main/scala/wasm4s/Wasm.scala
@@ -28,6 +28,7 @@ sealed abstract class WasmImportDesc
 
 object WasmImportDesc {
   final case class Func(id: WasmFunctionName, typ: WasmFunctionType) extends WasmImportDesc
+  final case class Tag(id: WasmTagName, typ: WasmFunctionType) extends WasmImportDesc
 }
 
 /** @see
@@ -48,6 +49,9 @@ case class WasmLocal(
     val typ: WasmType,
     val isParameter: Boolean // for text
 ) extends WasmNamedDefinitionField[WasmLocalName]
+
+final case class WasmTag(val name: WasmTagName, val typ: WasmFunctionTypeName)
+    extends WasmNamedDefinitionField[WasmTagName]
 
 case class WasmGlobal(
     val name: WasmGlobalName,
@@ -193,6 +197,7 @@ class WasmModule(
     private val _definedFunctions: mutable.ListBuffer[WasmFunction] = new mutable.ListBuffer(),
     // val tables: List[WasmTable] = Nil,
     // val memories: List[WasmMemory] = Nil,
+    private val _tags: mutable.ListBuffer[WasmTag] = new mutable.ListBuffer(),
     private val _globals: mutable.ListBuffer[WasmGlobal] = new mutable.ListBuffer(),
     private val _exports: mutable.ListBuffer[WasmExport[_]] = new mutable.ListBuffer(),
     private var _startFunction: Option[WasmFunctionName] = None,
@@ -207,6 +212,7 @@ class WasmModule(
   def addArrayType(typ: WasmArrayType): Unit = _arrayTypes.addOne(typ)
   def addFunctionType(typ: WasmFunctionType): Unit = _functionTypes.addOne(typ)
   def addRecGroupType(typ: WasmStructType): Unit = _recGroupTypes.addOne(typ)
+  def addTag(tag: WasmTag): Unit = _tags.addOne(tag)
   def addGlobal(typ: WasmGlobal): Unit = _globals.addOne(typ)
   def addExport(exprt: WasmExport[_]) = _exports.addOne(exprt)
   def setStartFunction(startFunction: WasmFunctionName): Unit = _startFunction = Some(startFunction)
@@ -217,6 +223,7 @@ class WasmModule(
   def arrayTypes = List(WasmArrayType.itables, WasmArrayType.u16Array) ++ _arrayTypes.toList
   def imports = _imports.toList
   def definedFunctions = _definedFunctions.toList
+  def tags: List[WasmTag] = _tags.toList
   def globals = _globals.toList
   def exports = _exports.toList
   def startFunction: Option[WasmFunctionName] = _startFunction

--- a/wasm/src/main/scala/wasm4s/WasmContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmContext.scala
@@ -131,6 +131,8 @@ trait TypeDefinableWasmContext extends ReadOnlyWasmContext { this: WasmContext =
       )
     )
 
+  val exceptionTagName: WasmTagName
+
   def addFunctionType(sig: WasmFunctionSignature): WasmFunctionTypeName = {
     functionSignatures.get(sig) match {
       case None =>
@@ -239,6 +241,14 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
 
   def putClassInfo(name: IRNames.ClassName, info: WasmClassInfo): Unit =
     classInfo.put(name, info)
+
+  val exceptionTagName: WasmTagName = WasmTagName("exception")
+
+  locally {
+    val exceptionSig = WasmFunctionSignature(List(WasmAnyRef), Nil)
+    val exceptionFunType = addFunctionType(exceptionSig)
+    module.addTag(WasmTag(exceptionTagName, exceptionFunType))
+  }
 
   private def addHelperImport(
       name: WasmFunctionName,


### PR DESCRIPTION
Unfortunately, we cannot write unit tests for `TryCatch` and `TryFinally` yet. The latest Node.js nightly build is still using an old version of v8 that does not support the latest spec for Wasm exception handling. However, it possible to run the `sample` from a web browser when it contains `try..catch` and `try..finally`.