### PR TITLE
Fix #35: Support Match

### DIFF
--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -23,6 +23,7 @@ object TestSuites {
     TestSuite("testsuite.core.StaticMethodTest"),
     TestSuite("testsuite.core.ThrowablesTest"),
     TestSuite("testsuite.core.ToStringTest"),
+    TestSuite("testsuite.core.MatchTest"),
     TestSuite("testsuite.core.WrapUnwrapThrowableTest")
   )
 }

--- a/test-suite/src/main/scala/testsuite/core/MatchTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/MatchTest.scala
@@ -1,0 +1,53 @@
+package testsuite.core
+
+import testsuite.Assert.ok
+
+object MatchTest {
+  def main(): Unit = {
+    testFib()
+    testString()
+    testNull()
+  }
+
+  private def testFib(): Unit = {
+    def test(x: Int, expected: Int) = ok(fib(x) == expected)
+    def fib(x: Int): Int = x match {
+      case 0     => 0
+      case 1 | 2 => 1
+      case _     => fib(x - 1) + fib(x - 2)
+    }
+    test(0, 0)
+    test(1, 1)
+    test(2, 1)
+    test(3, 2)
+    test(4, 3)
+    test(5, 5)
+    test(6, 8)
+  }
+
+  private def testString(): Unit = {
+    def test(x: String, expected: String) = ok(animalSound(x) == expected)
+    def animalSound(animal: String) = animal match {
+      case "dog" => "bow-wow"
+      case "cat" => "meow"
+      case _     => "unknown"
+    }
+    test("dog", "bow-wow")
+    test("cat", "meow")
+    test("???", "unknown")
+  }
+
+  private def testNull(): Unit = {
+    def strTest(x: String) = x match {
+      case null  => "null"
+      case "foo" => "bar"
+      case "bar" => "babar"
+      case x     => x
+    }
+    ok(strTest(null) == "null")
+    ok(strTest("a") == "a")
+  }
+
+  // TODO: Add test case that no default case _
+  // we can't test with node v22 at this moment due to the lack of try_table
+}


### PR DESCRIPTION
The following Scala code will be compiled to

```scala
def fib(x: Int): Int = x match {
  case 0     => 0
  case 1 | 2 => 1
  case _     => fib(x - 1) + fib(x - 2)
}
```

```wasm
block $done (result i32)
  block $default
    block $case1
      block $case2
        local.get $selector
        i32.const 0
        i32.eq
        br_if $case1
        local.get $selector
        i32.const 1
        i32.eq
        br_if $case2
        local.get $selector
        i32.const 2
        i32.eq
        br_if $case2
        br $default
      end
      i32.const 1
      br $done
    end
    i32.const 0
    br $done
  end
  ;; default
end
```

I cound't find a practical way for using `br_table`. It seems that regardless, we still need to translate the selector into a range from 0 to X for `br_table` input.
In that case, it appears equivalent to convert the match patterns into a sequence of equality checks followed by `br_if` instruction.

https://github.com/tanishiking/scala-wasm/issues/35