### PR TITLE
Fix #44: Support non-native JS classes.

### DIFF
--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -20,6 +20,7 @@ object TestSuites {
     TestSuite("testsuite.core.HijackedClassesDispatchTest"),
     TestSuite("testsuite.core.HijackedClassesMonoTest"),
     TestSuite("testsuite.core.HijackedClassesUpcastTest"),
+    TestSuite("testsuite.core.NonNativeJSClassTest"),
     TestSuite("testsuite.core.StaticFieldsTest"),
     TestSuite("testsuite.core.StaticMethodTest"),
     TestSuite("testsuite.core.ThrowablesTest"),

--- a/test-suite/src/main/scala/testsuite/core/NonNativeJSClassTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/NonNativeJSClassTest.scala
@@ -1,0 +1,108 @@
+package testsuite.core
+
+import scala.scalajs.js
+
+import testsuite.Assert._
+
+object NonNativeJSClassTest {
+  def main(): Unit = {
+    testBasic()
+    testClassCaptures()
+    testInheritanceAndSuper()
+    testObject()
+  }
+
+  def testBasic(): Unit = {
+    val o = new MyClass("string param")
+
+    // Field access and initialization
+    assertSame(0, o.asInstanceOf[js.Dynamic].i)
+    assertSame(0, o.i)
+    o.i = 42
+    assertSame(42, o.i)
+
+    // Method call
+    assertSame(8, o.foobar(5))
+
+    // Property read/write
+    assertSame("prop string param", o.prop)
+    o.prop = "foobar"
+    assertSame("prop set foobar", o.prop)
+
+    // Instance test -- also ensures that we get the same MyClass class
+    assertSame(true, (o: Any).isInstanceOf[MyClass])
+  }
+
+  def testClassCaptures(): Unit = {
+    def localJSClass(capture: Int): js.Dynamic = {
+      class Local(s: String) extends MyClass(s) {
+        def getCapture(): Int = capture
+      }
+      js.constructorOf[Local]
+    }
+
+    // Create classes
+
+    val localClass1 = localJSClass(5)
+    assertSame("function", js.typeOf(localClass1))
+    val localClass2 = localJSClass(6)
+    assertSame(true, localClass2 ne localClass1)
+
+    val obj1 = js.Dynamic.newInstance(localClass1)("foobar")
+    assertSame("prop foobar", obj1.prop)
+    assertSame(5, obj1.getCapture())
+
+    val obj2 = js.Dynamic.newInstance(localClass2)("babar")
+    assertSame("prop babar", obj2.prop)
+    assertSame(6, obj2.getCapture())
+
+    // Instance tests -- the two local classes are independent
+    assertSame(true, (obj1: Any).isInstanceOf[MyClass])
+    assertSame(true, js.special.instanceof(obj1, localClass1))
+    assertSame(false, js.special.instanceof(obj1, localClass2))
+    assertSame(true, js.special.instanceof(obj2, localClass2))
+  }
+
+  def testInheritanceAndSuper(): Unit = {
+    val sub = new Sub()
+
+    assertSame("prop subarg sub", sub.prop)
+    sub.prop = "new value"
+    assertSame("prop set from sub new value sub", sub.prop)
+
+    assertSame(15, sub.foobar(6))
+
+    assertSame(true, (sub: Any).isInstanceOf[MyClass])
+    assertSame(true, (sub: Any).isInstanceOf[Sub])
+  }
+
+  def testObject(): Unit = {
+    assertSame(5, MyObject.foo(4))
+
+    val obj1 = MyObject
+    val obj2 = MyObject
+    assertSame(obj1, obj2)
+  }
+
+  class MyClass(private var s: String) extends js.Object {
+    var i: Int = _
+
+    def foobar(x: Int): Int = x + 3
+
+    def prop: String = "prop " + s
+    def prop_=(v: String): Unit =
+      s = "set " + v
+  }
+
+  class Sub extends MyClass("subarg") {
+    override def foobar(x: Int): Int = super.foobar(x * 2)
+
+    override def prop: String = super.prop + " sub"
+    override def prop_=(v: String): Unit =
+      super.prop_=("from sub " + v)
+  }
+
+  object MyObject extends js.Object {
+    def foo(x: Int): Int = x + 1
+  }
+}

--- a/test-suite/src/main/scala/testsuite/core/NonNativeJSClassTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/NonNativeJSClassTest.scala
@@ -10,6 +10,7 @@ object NonNativeJSClassTest {
     testClassCaptures()
     testInheritanceAndSuper()
     testObject()
+    testNewTarget()
   }
 
   def testBasic(): Unit = {
@@ -84,6 +85,14 @@ object NonNativeJSClassTest {
     assertSame(obj1, obj2)
   }
 
+  def testNewTarget(): Unit = {
+    val parent = new NewTargetParent
+    assertSame(js.constructorOf[NewTargetParent], parent.myNewTarget)
+
+    val child = new NewTargetChild
+    assertSame(js.constructorOf[NewTargetChild], child.myNewTarget)
+  }
+
   class MyClass(private var s: String) extends js.Object {
     var i: Int = _
 
@@ -105,4 +114,10 @@ object NonNativeJSClassTest {
   object MyObject extends js.Object {
     def foo(x: Int): Int = x + 1
   }
+
+  class NewTargetParent extends js.Object {
+    val myNewTarget = js.`new`.target
+  }
+
+  class NewTargetChild extends NewTargetParent
 }

--- a/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
+++ b/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
@@ -779,8 +779,8 @@ object HelperFunctions {
       val List(fromParam) = fctx.paramIndices
       import fctx.instrs
 
-      val from = fctx.addLocal(fctx.genSyntheticLocalName(), WasmRefNullType(heapType))
-      val result = fctx.addLocal(fctx.genSyntheticLocalName(), WasmRefNullType(heapType))
+      val from = fctx.addSyntheticLocal(WasmRefNullType(heapType))
+      val result = fctx.addSyntheticLocal(WasmRefNullType(heapType))
 
       instrs += LOCAL_GET(fromParam)
       instrs += REF_CAST(HeapType(heapType))

--- a/wasm/src/main/scala/ir2wasm/LoaderContent.scala
+++ b/wasm/src/main/scala/ir2wasm/LoaderContent.scala
@@ -72,9 +72,9 @@ const scalaJSHelpers = {
 
   // Closure
   closure: (f, data) => f.bind(void 0, data),
-  closureThis: (f, data) => function(...args) { return f(this, data, ...args); },
+  closureThis: (f, data) => function(...args) { return f(data, this, ...args); },
   closureRest: (f, data, n) => ((...args) => f(data, ...args.slice(0, n), args.slice(n))),
-  closureThisRest: (f, data, n) => function(...args) { return f(this, data, ...args.slice(0, n), args.slice(n)); },
+  closureThisRest: (f, data, n) => function(...args) { return f(data, this, ...args.slice(0, n), args.slice(n)); },
 
   // Strings
   emptyString: () => "",

--- a/wasm/src/main/scala/ir2wasm/LoaderContent.scala
+++ b/wasm/src/main/scala/ir2wasm/LoaderContent.scala
@@ -214,9 +214,9 @@ const scalaJSHelpers = {
   createJSClass: (data, superClass, preSuperStats, superArgs, postSuperStats) => {
     return class extends superClass {
       constructor(...args) {
-        var preSuperEnv = preSuperStats(data, ...args);
-        super(...superArgs(data, preSuperEnv, ...args));
-        postSuperStats(data, preSuperEnv, this, ...args);
+        var preSuperEnv = preSuperStats(data, new.target, ...args);
+        super(...superArgs(data, preSuperEnv, new.target, ...args));
+        postSuperStats(data, preSuperEnv, new.target, this, ...args);
       }
     };
   },

--- a/wasm/src/main/scala/ir2wasm/Preprocessor.scala
+++ b/wasm/src/main/scala/ir2wasm/Preprocessor.scala
@@ -52,6 +52,7 @@ object Preprocessor {
       new WasmClassInfo(
         clazz.name.name,
         clazz.kind,
+        clazz.jsClassCaptures,
         infos,
         allFieldDefs,
         clazz.superClass.map(_.name),

--- a/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
@@ -489,7 +489,9 @@ class WasmBuilder {
         Some(clazz.className),
         WasmFunctionName.preSuperStats(clazz.className),
         Some(jsClassCaptures),
-        None,
+        preSuperVarDefs = None,
+        hasNewTarget = true,
+        receiverTyp = None,
         ctor.args,
         List(preSuperEnvTyp)
       )
@@ -513,7 +515,8 @@ class WasmBuilder {
         WasmFunctionName.superArgs(clazz.className),
         Some(jsClassCaptures),
         Some(preSuperDecls),
-        None,
+        hasNewTarget = true,
+        receiverTyp = None,
         ctor.args,
         List(WasmAnyRef) // a js.Array
       )
@@ -533,7 +536,8 @@ class WasmBuilder {
         WasmFunctionName.postSuperStats(clazz.className),
         Some(jsClassCaptures),
         Some(preSuperDecls),
-        Some(WasmAnyRef),
+        hasNewTarget = true,
+        receiverTyp = Some(WasmAnyRef),
         ctor.args,
         List(WasmAnyRef)
       )

--- a/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
@@ -173,9 +173,10 @@ private class WasmExpressionBuilder private (
       case t: IRTrees.JSPrivateSelect   => genJSPrivateSelect(t)
       case t: IRTrees.JSSuperSelect     => genJSSuperSelect(t)
       case t: IRTrees.JSSuperMethodCall => genJSSuperMethodCall(t)
+      case t: IRTrees.JSNewTarget       => genJSNewTarget(t)
 
-      case _: IRTrees.JSNewTarget | _: IRTrees.JSImportMeta | _: IRTrees.JSImportCall |
-          _: IRTrees.ForIn | _: IRTrees.ApplyDynamicImport =>
+      case _: IRTrees.JSImportMeta | _: IRTrees.JSImportCall | _: IRTrees.ForIn |
+          _: IRTrees.ApplyDynamicImport =>
         throw new NotImplementedError(tree.toString())
 
       case _: IRTrees.RecordSelect | _: IRTrees.RecordValue | _: IRTrees.Transient |
@@ -2139,6 +2140,12 @@ private class WasmExpressionBuilder private (
     genTree(tree.method, IRTypes.AnyType)
     genJSArgsArray(tree.args)
     instrs += CALL(FuncIdx(WasmFunctionName.jsSuperCall))
+
+    IRTypes.AnyType
+  }
+
+  private def genJSNewTarget(tree: IRTrees.JSNewTarget): IRTypes.Type = {
+    genReadStorage(fctx.newTargetStorage)
 
     IRTypes.AnyType
   }

--- a/wasm/src/main/scala/wasm4s/Names.scala
+++ b/wasm/src/main/scala/wasm4s/Names.scala
@@ -12,10 +12,12 @@ object Names {
       val suffix = this match {
         case _: WasmLocalName                               => "local"
         case _: WasmGlobalName.WasmModuleInstanceName       => "g_instance"
+        case _: WasmGlobalName.WasmJSClassName              => "g_jsclass"
         case _: WasmGlobalName.WasmGlobalVTableName         => "g_vtable"
         case _: WasmGlobalName.WasmGlobalITableName         => "g_itable"
         case _: WasmGlobalName.WasmGlobalConstantStringName => "str_const"
         case _: WasmGlobalName.WasmGlobalStaticFieldName    => "f_static"
+        case _: WasmGlobalName.WasmGlobalJSPrivateFieldName => "g_jspfield"
         case _: WasmFunctionName                            => "fun"
         case _: WasmFieldName                               => "field"
         case _: WasmTagName                                 => "tag"
@@ -62,6 +64,14 @@ object Names {
         name.nameString
       )
     }
+
+    final case class WasmJSClassName private (override private[wasm4s] val name: String)
+        extends WasmGlobalName(name)
+    object WasmJSClassName {
+      def apply(name: IRNames.ClassName): WasmJSClassName =
+        new WasmJSClassName(name.nameString)
+    }
+
     final case class WasmGlobalVTableName private (override private[wasm4s] val name: String)
         extends WasmGlobalName(name)
     object WasmGlobalVTableName {
@@ -100,6 +110,14 @@ object Names {
     object WasmGlobalStaticFieldName {
       def apply(fieldName: IRNames.FieldName): WasmGlobalStaticFieldName =
         new WasmGlobalStaticFieldName(s"static___${fieldName.nameString}")
+    }
+
+    final case class WasmGlobalJSPrivateFieldName private (
+        override private[wasm4s] val name: String
+    ) extends WasmGlobalName(name)
+    object WasmGlobalJSPrivateFieldName {
+      def apply(fieldName: IRNames.FieldName): WasmGlobalJSPrivateFieldName =
+        new WasmGlobalJSPrivateFieldName(s"jspfield___${fieldName.nameString}")
     }
   }
 
@@ -149,6 +167,16 @@ object Names {
       new WasmFunctionName("instanceTest", clazz.nameString)
     def clone(clazz: IRNames.ClassName): WasmFunctionName =
       new WasmFunctionName("clone", clazz.nameString)
+    def loadJSClass(clazz: IRNames.ClassName): WasmFunctionName =
+      new WasmFunctionName("loadJSClass", clazz.nameString)
+    def createJSClassOf(clazz: IRNames.ClassName): WasmFunctionName =
+      new WasmFunctionName("createJSClassOf", clazz.nameString)
+    def preSuperStats(clazz: IRNames.ClassName): WasmFunctionName =
+      new WasmFunctionName("preSuperStats", clazz.nameString)
+    def superArgs(clazz: IRNames.ClassName): WasmFunctionName =
+      new WasmFunctionName("superArgs", clazz.nameString)
+    def postSuperStats(clazz: IRNames.ClassName): WasmFunctionName =
+      new WasmFunctionName("postSuperStats", clazz.nameString)
 
     val start = new WasmFunctionName("start", "start")
 
@@ -240,6 +268,15 @@ object Names {
         JSBinaryOp.** -> helper("jsExponent")
       )
     }
+
+    val newSymbol = helper("newSymbol")
+    val createJSClass = helper("createJSClass")
+    val installJSField = helper("installJSField")
+    val installJSMethod = helper("installJSMethod")
+    val installJSProperty = helper("installJSProperty")
+    val jsSuperGet = helper("jsSuperGet")
+    val jsSuperSet = helper("jsSuperSet")
+    val jsSuperCall = helper("jsSuperCall")
 
     // Wasm internal helpers
 

--- a/wasm/src/main/scala/wasm4s/Names.scala
+++ b/wasm/src/main/scala/wasm4s/Names.scala
@@ -51,6 +51,8 @@ object Names {
     def fromIR(name: IRNames.LocalName) = new WasmLocalName(name.nameString)
     def fromStr(str: String) = new WasmLocalName(str)
     def synthetic(id: Int) = new WasmLocalName(s"local___$id")
+
+    val newTarget = new WasmLocalName("new.target")
     val receiver = new WasmLocalName("___<this>")
   }
 

--- a/wasm/src/main/scala/wasm4s/Types.scala
+++ b/wasm/src/main/scala/wasm4s/Types.scala
@@ -53,6 +53,9 @@ object Types {
 
     /** Non-null `anyref`. */
     val any: WasmRefType = WasmRefType(WasmHeapType.Simple.Any)
+
+    /** Non-null `func`. */
+    val func: WasmRefType = WasmRefType(WasmHeapType.Simple.Func)
   }
 
   sealed trait WasmHeapType {

--- a/wasm/src/main/scala/wasm4s/WasmContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmContext.scala
@@ -209,6 +209,9 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
   import WasmContext._
 
   override protected var nextItableIdx: Int = 0
+
+  private val _jsPrivateFieldNames: mutable.ListBuffer[IRNames.FieldName] =
+    new mutable.ListBuffer()
   private val _funcDeclarations: mutable.LinkedHashSet[WasmFunctionName] =
     new mutable.LinkedHashSet()
 
@@ -241,6 +244,9 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
       nextItableIdx += 1
     }
   }
+
+  def addJSPrivateFieldName(fieldName: IRNames.FieldName): Unit =
+    _jsPrivateFieldNames += fieldName
 
   val exceptionTagName: WasmTagName = WasmTagName("exception")
 
@@ -284,22 +290,22 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
 
   addHelperImport(
     WasmFunctionName.closure,
-    List(WasmRefType(WasmHeapType.Simple.Func), WasmAnyRef),
+    List(WasmRefType.func, WasmAnyRef),
     List(WasmRefType.any)
   )
   addHelperImport(
     WasmFunctionName.closureThis,
-    List(WasmRefType(WasmHeapType.Simple.Func), WasmAnyRef),
+    List(WasmRefType.func, WasmAnyRef),
     List(WasmRefType.any)
   )
   addHelperImport(
     WasmFunctionName.closureRest,
-    List(WasmRefType(WasmHeapType.Simple.Func), WasmAnyRef),
+    List(WasmRefType.func, WasmAnyRef),
     List(WasmRefType.any)
   )
   addHelperImport(
     WasmFunctionName.closureThisRest,
-    List(WasmRefType(WasmHeapType.Simple.Func), WasmAnyRef),
+    List(WasmRefType.func, WasmAnyRef),
     List(WasmRefType.any)
   )
 
@@ -361,6 +367,43 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
     addHelperImport(name, List(WasmAnyRef, WasmAnyRef), List(resultType))
   }
 
+  addHelperImport(WasmFunctionName.newSymbol, Nil, List(WasmAnyRef))
+  addHelperImport(
+    WasmFunctionName.createJSClass,
+    List(WasmAnyRef, WasmAnyRef, WasmRefType.func, WasmRefType.func, WasmRefType.func),
+    List(WasmRefType.any)
+  )
+  addHelperImport(
+    WasmFunctionName.installJSField,
+    List(WasmAnyRef, WasmAnyRef, WasmAnyRef),
+    Nil
+  )
+  addHelperImport(
+    WasmFunctionName.installJSMethod,
+    List(WasmAnyRef, WasmAnyRef, WasmInt32, WasmAnyRef, WasmRefType.func, WasmInt32),
+    Nil
+  )
+  addHelperImport(
+    WasmFunctionName.installJSProperty,
+    List(WasmAnyRef, WasmAnyRef, WasmInt32, WasmAnyRef, WasmFuncRef, WasmFuncRef),
+    Nil
+  )
+  addHelperImport(
+    WasmFunctionName.jsSuperGet,
+    List(WasmAnyRef, WasmAnyRef, WasmAnyRef),
+    List(WasmAnyRef)
+  )
+  addHelperImport(
+    WasmFunctionName.jsSuperSet,
+    List(WasmAnyRef, WasmAnyRef, WasmAnyRef, WasmAnyRef),
+    Nil
+  )
+  addHelperImport(
+    WasmFunctionName.jsSuperCall,
+    List(WasmAnyRef, WasmAnyRef, WasmAnyRef, WasmAnyRef),
+    List(WasmAnyRef)
+  )
+
   def complete(
       moduleInitializers: List[ModuleInitializer.Initializer],
       classesWithStaticInit: List[IRNames.ClassName]
@@ -407,6 +450,15 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
         instrs += WasmInstr.STRUCT_NEW(WasmTypeName.WasmITableTypeName(iface.name))
         instrs += WasmInstr.ARRAY_SET(WasmImmediate.TypeIdx(WasmTypeName.WasmArrayTypeName.itables))
       }
+    }
+
+    // Initialize the JS private field symbols
+
+    for (fieldName <- _jsPrivateFieldNames) {
+      instrs += WasmInstr.CALL(WasmImmediate.FuncIdx(WasmFunctionName.newSymbol))
+      instrs += WasmInstr.GLOBAL_SET(
+        WasmImmediate.GlobalIdx(WasmGlobalName.WasmGlobalJSPrivateFieldName(fieldName))
+      )
     }
 
     // Initialize the constant string globals
@@ -513,6 +565,7 @@ object WasmContext {
   final class WasmClassInfo(
       val name: IRNames.ClassName,
       val kind: ClassKind,
+      val jsClassCaptures: Option[List[IRTrees.ParamDef]],
       private var _methods: List[WasmFunctionInfo],
       val allFieldDefs: List[IRTrees.FieldDef],
       val superClass: Option[IRNames.ClassName],

--- a/wasm/src/main/scala/wasm4s/WasmContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmContext.scala
@@ -176,7 +176,7 @@ trait TypeDefinableWasmContext extends ReadOnlyWasmContext { this: WasmContext =
   }
 
   def getClosureDataStructType(captureParamTypes: List[IRTypes.Type]): WasmStructType = {
-    closureDataTypes.getOrElse(
+    closureDataTypes.getOrElseUpdate(
       captureParamTypes, {
         val fields: List[WasmStructField] =
           for ((tpe, i) <- captureParamTypes.zipWithIndex)


### PR DESCRIPTION
The handling of the IR Trees themselves are straightforward. The real work happens in `WasmBuilder`, and in particular in `genCreateJSClassFunction`. The main difficulty is that we need to decompose the JS constructor into three pieces, because the call to the super constructor must syntactically appear as such in the JavaScript source of the constructor. There is a big comment in the code that explains the decomposition.