### PR TITLE
Add tests for try..catch and try.finally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ $ nvm use 22
 ```
 
 Otherwise, you can [manually download nightly builds of Node.js](https://nodejs.org/download/nightly/).
+You will need a nightly of v22 from 2024/04/01 or later.
 
 ### Setup
 
@@ -40,11 +41,11 @@ It contains the WebAsembly Text Format representation of `main.wasm`, for debugg
 
 You can also use the `run.mjs` script to play with `@JSExportTopLevel` exports.
 
-- Run from the command line with `node run.mjs`.
+- Run from the command line with `node --experimental-wasm-exnref run.mjs`.
 - Run from the command line with `DENO_V8_FLAGS=--experimental-wasm-exnref deno run --allow-read run.mjs`.
 - Run from the browser by starting an HTTP server (e.g., `python -m http.server`) and navigate to `testrun.html`.
 
-If you encounter the `Invalid opcode 0x1f` error with Node.js, try using Deno or running the code in a browser instead.
+If you encounter the `Invalid opcode 0x1f` error with Node.js, you need to use a more recent nightly build (minimum required: v22 nightly from 2024/04/01).
 
 ### Test suite
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import org.scalajs.jsenv.nodejs.NodeJSEnv
+
 import org.scalajs.linker.interface.ESVersion
 import org.scalajs.linker.interface.OutputPatterns
 
@@ -17,6 +19,12 @@ inThisBuild(Def.settings(
   ),
   scalaJSLinkerConfig ~= {
     _.withESFeatures(_.withESVersion(ESVersion.ES2016))
+  },
+  jsEnv := {
+    // Enable support for exnref and try_table
+    new NodeJSEnv(
+      NodeJSEnv.Config().withArgs(List("--experimental-wasm-exnref"))
+    )
   },
 ))
 
@@ -66,7 +74,6 @@ lazy val testSuite = project
     scalaVersion := scalaV,
     scalaJSUseMainModuleInitializer := true,
     Compile / jsEnv := {
-      import org.scalajs.jsenv.nodejs.NodeJSEnv
       val cp = Attributed
         .data((Compile / fullClasspath).value)
         .mkString(";")
@@ -74,7 +81,11 @@ lazy val testSuite = project
         "SCALAJS_CLASSPATH" -> cp,
         "SCALAJS_MODE" -> "testsuite",
       )
-      new NodeJSEnv(NodeJSEnv.Config().withEnv(env).withArgs(List("--enable-source-maps")))
+      new NodeJSEnv(
+        NodeJSEnv.Config()
+          .withEnv(env)
+          .withArgs(List("--enable-source-maps", "--experimental-wasm-exnref"))
+      )
     },
     Compile / jsEnvInput := (`cli` / Compile / jsEnvInput).value
   )

--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -29,6 +29,7 @@ object TestSuites {
     TestSuite("testsuite.core.NonNativeJSClassTest"),
     TestSuite("testsuite.core.StaticFieldsTest"),
     TestSuite("testsuite.core.StaticMethodTest"),
+    TestSuite("testsuite.core.ThrowAndTryTest"),
     TestSuite("testsuite.core.ThrowablesTest"),
     TestSuite("testsuite.core.ToStringTest"),
     TestSuite("testsuite.core.MatchTest"),

--- a/test-suite/src/main/scala/testsuite/core/ThrowAndTryTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/ThrowAndTryTest.scala
@@ -1,0 +1,72 @@
+package testsuite.core
+
+import testsuite.Assert._
+
+object ThrowAndTryTest {
+  def main(): Unit = {
+    testTryCatch()
+    testTryFinally()
+  }
+
+  private def testTryCatch(): Unit = {
+    try {
+      doNotThrow()
+    } catch {
+      case e: IllegalArgumentException =>
+        fail()
+    }
+
+    try {
+      throwIllegalArgument()
+      fail()
+    } catch {
+      case e: IllegalArgumentException =>
+        assertSame("boom", e.getMessage())
+    }
+
+    try {
+      try {
+        throwIllegalArgument()
+        fail()
+      } catch {
+        case e: UnsupportedOperationException =>
+          // This one should not be caught
+          fail()
+      }
+      fail() // the exception should have been rethrown
+    } catch {
+      case e: IllegalArgumentException =>
+        assertSame("boom", e.getMessage())
+    }
+  }
+
+  private def testTryFinally(): Unit = {
+    var didFinally = false
+
+    try {
+      try {
+        throwIllegalArgument()
+        fail()
+      } finally {
+        didFinally = true
+      }
+      fail() // the exception should have been rethrown
+    } catch {
+      case e: IllegalArgumentException => ()
+    }
+    ok(didFinally)
+
+    didFinally = false
+    try {
+      doNotThrow()
+    } finally {
+      didFinally = true
+    }
+    ok(didFinally)
+  }
+
+  private def throwIllegalArgument(): Int =
+    throw new IllegalArgumentException("boom")
+
+  private def doNotThrow(): Int = 5
+}


### PR DESCRIPTION
Since Node.js 22 nightly from 2024/04/01, support for the new exceptions with `exnref` and `try_table` is available under a flag.