### PR TITLE
Add const string to data section

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,5 +4,9 @@ maxColumn = 100
 literals.hexDigits = "Upper"
 
 project.excludeFilters = [
+  // to avoid "invalid unicode surrogate pair"
+  "/test-suite/src/main/scala/testsuite/core/StringEncodingTest.scala"
+
+  // imported sources
   "/scalajs-test-suite/fetched-sources/.*"
 ]

--- a/cli/src/main/scala/TestSuites.scala
+++ b/cli/src/main/scala/TestSuites.scala
@@ -36,6 +36,7 @@ object TestSuites {
     TestSuite("testsuite.core.ToStringTest"),
     TestSuite("testsuite.core.UnitPatMatTest"),
     TestSuite("testsuite.core.MatchTest"),
-    TestSuite("testsuite.core.WrapUnwrapThrowableTest")
+    TestSuite("testsuite.core.WrapUnwrapThrowableTest"),
+    TestSuite("testsuite.core.StringEncodingTest")
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "wasm4s",
+  "name": "scala-wasm",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/test-suite/src/main/scala/testsuite/core/HijackedClassesMonoTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/HijackedClassesMonoTest.scala
@@ -4,10 +4,8 @@ import testsuite.Assert.ok
 
 object HijackedClassesMonoTest {
   def main(): Unit = {
-    ok(
-      testInteger(5) &&
-        testString("foo")
-    )
+    ok(testInteger(5))
+    ok(testString("foo"))
   }
 
   def testInteger(x: Int): Boolean = {
@@ -18,4 +16,5 @@ object HijackedClassesMonoTest {
     foo.length() == 3 &&
     foo.hashCode() == 101574
   }
+
 }

--- a/test-suite/src/main/scala/testsuite/core/StringEncodingTest.scala
+++ b/test-suite/src/main/scala/testsuite/core/StringEncodingTest.scala
@@ -1,0 +1,25 @@
+package testsuite.core
+
+import testsuite.Assert._
+
+object StringEncodingTest {
+  def main(): Unit = {
+    illformedUTF16Test()
+    wellformedUTF16Test()
+  }
+
+  def illformedUTF16Test(): Unit = {
+    val s = "\ud834a\udd1e"
+    assertSame(3, s.length())
+    assertSame(0xd834, s.charAt(0).toInt)
+    assertSame('a'.toInt, s.charAt(1).toInt)
+    assertSame(0xdd1e, s.charAt(2).toInt)
+  }
+
+  def wellformedUTF16Test(): Unit = {
+    val s = "\ud834\udd1e"
+    assertSame(2, s.length())
+    assertSame(0xd834, s.charAt(0).toInt)
+    assertSame(0xdd1e, s.charAt(1).toInt)
+  }
+}

--- a/wasm/src/main/scala/converters/WasmTextWriter.scala
+++ b/wasm/src/main/scala/converters/WasmTextWriter.scala
@@ -32,9 +32,9 @@ class WasmTextWriter {
         module.exports.foreach(writeExport)
         module.startFunction.foreach(writeStart)
         module.elements.foreach(writeElement)
+        module.data.foreach(writeData)
       }
     )
-    // context.gcTypes
   }
 
   private def writeGCTypeDefinition(
@@ -257,6 +257,18 @@ class WasmTextWriter {
     )
   }
 
+  private def writeData(data: WasmData)(implicit b: WatBuilder): Unit = {
+    b.newLineList(
+      "data", {
+        b.appendElement(data.name.show)
+        data.mode match {
+          case WasmData.Mode.Passive => ()
+        }
+        b.appendElement("\"" + data.bytes.map("\\%02x".format(_)).mkString + "\"")
+      }
+    )
+  }
+
   private def writeImmediate(i: WasmImmediate, instr: WasmInstr)(implicit b: WatBuilder): Unit = {
     def floatString(v: Double): String = {
       if (v.isNaN()) "nan"
@@ -290,8 +302,8 @@ class WasmTextWriter {
       case WasmImmediate.LabelIdx(i) => s"$$${i.toString}" // `loop 0` seems to be invalid
       case WasmImmediate.LabelIdxVector(indices) =>
         indices.map(i => "$" + i.value).mkString(" ")
-      case WasmImmediate.TagIdx(name) =>
-        name.show
+      case WasmImmediate.TagIdx(name)  => name.show
+      case WasmImmediate.DataIdx(name) => name.show
       case WasmImmediate.CatchClauseVector(clauses) =>
         for (clause <- clauses) {
           b.appendElement("(" + clause.mnemonic)

--- a/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
@@ -637,7 +637,7 @@ private class WasmExpressionBuilder private (
         instrs += WasmInstr.REF_NULL(HeapType(Types.WasmHeapType.Simple.None))
 
       case v: IRTrees.StringLiteral =>
-        instrs += ctx.getConstantStringInstr(v.value)
+        instrs ++= ctx.getConstantStringInstr(v.value)
 
       case v: IRTrees.ClassOf =>
         v.typeRef match {
@@ -2182,7 +2182,7 @@ private class WasmExpressionBuilder private (
               instrs += I32_EQ
               instrs += BR_IF(label)
             case IRTrees.StringLiteral(value) =>
-              instrs += ctx.getConstantStringInstr(value)
+              instrs ++= ctx.getConstantStringInstr(value)
               instrs += CALL(FuncIdx(WasmFunctionName.is))
               instrs += BR_IF(label)
             case IRTrees.Null() =>

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -279,6 +279,8 @@ object WasmInstr {
   case class ARRAY_NEW_DEFAULT(i: TypeIdx) extends WasmInstr("array.new_default", 0xFB07, List(i))
   case class ARRAY_NEW_FIXED(i: TypeIdx, size: I32)
       extends WasmInstr("array.new_fixed", 0xFB08, List(i, size))
+  case class ARRAY_NEW_DATA(i: TypeIdx, d: DataIdx)
+      extends WasmInstr("array.new_data", 0xFB09, List(i, d))
   case class ARRAY_GET(i: TypeIdx) extends WasmInstr("array.get", 0xFB0B, List(i))
   case class ARRAY_GET_S(i: TypeIdx) extends WasmInstr("array.get_s", 0xFB0C, List(i))
   case class ARRAY_GET_U(i: TypeIdx) extends WasmInstr("array.get_u", 0xFB0D, List(i))
@@ -335,6 +337,7 @@ object WasmImmediate {
   case class LabelIdx(val value: Int) extends WasmImmediate
   case class LabelIdxVector(val value: List[LabelIdx]) extends WasmImmediate
   case class TypeIdx(val value: WasmTypeName) extends WasmImmediate
+  case class DataIdx(val value: WasmDataName) extends WasmImmediate
   case class TableIdx(val value: Int) extends WasmImmediate
   case class TagIdx(val value: WasmTagName) extends WasmImmediate
   case class LocalIdx(val value: WasmLocalName) extends WasmImmediate

--- a/wasm/src/main/scala/wasm4s/Names.scala
+++ b/wasm/src/main/scala/wasm4s/Names.scala
@@ -22,6 +22,7 @@ object Names {
         case _: WasmFunctionName                            => "fun"
         case _: WasmFieldName                               => "field"
         case _: WasmTagName                                 => "tag"
+        case _: WasmDataName                                => "data"
         case _: WasmExportName                              => "export"
         case _: WasmTypeName.WasmFunctionTypeName           => "ty"
         case _: WasmTypeName.WasmStructTypeName             => "struct"
@@ -297,6 +298,7 @@ object Names {
     // Wasm internal helpers
 
     val createStringFromData = helper("createStringFromData")
+    val stringLiteral = helper("stringLiteral")
     val typeDataName = helper("typeDataName")
     val createClassOf = helper("createClassOf")
     val getClassOf = helper("getClassOf")
@@ -553,6 +555,12 @@ object Names {
       extends WasmName(name)
   object WasmTagName {
     def fromStr(str: String): WasmTagName = new WasmTagName(str)
+  }
+
+  final case class WasmDataName private (override private[wasm4s] val name: String)
+      extends WasmName(name)
+  object WasmDataName {
+    val string = WasmDataName("string")
   }
 
   final case class WasmExportName private (override private[wasm4s] val name: String)

--- a/wasm/src/main/scala/wasm4s/Names.scala
+++ b/wasm/src/main/scala/wasm4s/Names.scala
@@ -16,7 +16,7 @@ object Names {
         case _: WasmGlobalName.WasmJSClassName              => "g_jsclass"
         case _: WasmGlobalName.WasmGlobalVTableName         => "g_vtable"
         case _: WasmGlobalName.WasmGlobalITableName         => "g_itable"
-        case _: WasmGlobalName.WasmGlobalConstantStringName => "str_const"
+        case WasmGlobalName.WasmGlobalStringLiteralCache    => "str_cache"
         case _: WasmGlobalName.WasmGlobalStaticFieldName    => "f_static"
         case _: WasmGlobalName.WasmGlobalJSPrivateFieldName => "g_jspfield"
         case _: WasmFunctionName                            => "fun"
@@ -108,14 +108,6 @@ object Names {
       )
     }
 
-    final case class WasmGlobalConstantStringName private (
-        override private[wasm4s] val name: String
-    ) extends WasmGlobalName(name)
-    object WasmGlobalConstantStringName {
-      def apply(index: Int): WasmGlobalConstantStringName =
-        new WasmGlobalConstantStringName(s"conststring___$index")
-    }
-
     final case class WasmGlobalStaticFieldName private (
         override private[wasm4s] val name: String
     ) extends WasmGlobalName(name)
@@ -131,6 +123,8 @@ object Names {
       def apply(fieldName: IRNames.FieldName): WasmGlobalJSPrivateFieldName =
         new WasmGlobalJSPrivateFieldName(s"jspfield___${fieldName.nameString}")
     }
+
+    object WasmGlobalStringLiteralCache extends WasmGlobalName("string_literal")
   }
 
   // final case class WasmGlobalName private (val name: String) extends WasmName(name) {

--- a/wasm/src/main/scala/wasm4s/Wasm.scala
+++ b/wasm/src/main/scala/wasm4s/Wasm.scala
@@ -50,6 +50,17 @@ case class WasmLocal(
 final case class WasmTag(val name: WasmTagName, val typ: WasmFunctionTypeName)
     extends WasmNamedDefinitionField[WasmTagName]
 
+final case class WasmData(val name: WasmDataName, val bytes: Array[Byte], mode: WasmData.Mode)
+    extends WasmNamedDefinitionField[WasmDataName]
+
+object WasmData {
+  sealed abstract class Mode
+  object Mode {
+    case object Passive extends Mode
+    // final case class Active
+  }
+}
+
 case class WasmGlobal(
     val name: WasmGlobalName,
     val typ: WasmType,
@@ -259,6 +270,7 @@ class WasmModule(
     // val tables: List[WasmTable] = Nil,
     // val memories: List[WasmMemory] = Nil,
     private val _tags: mutable.ListBuffer[WasmTag] = new mutable.ListBuffer(),
+    private val _data: mutable.ListBuffer[WasmData] = new mutable.ListBuffer(),
     private val _globals: mutable.ListBuffer[WasmGlobal] = new mutable.ListBuffer(),
     private val _exports: mutable.ListBuffer[WasmExport] = new mutable.ListBuffer(),
     private var _startFunction: Option[WasmFunctionName] = None,
@@ -274,6 +286,7 @@ class WasmModule(
   def addFunctionType(typ: WasmFunctionType): Unit = _functionTypes += typ
   def addRecGroupType(typ: WasmStructType): Unit = _recGroupTypes += typ
   def addTag(tag: WasmTag): Unit = _tags += tag
+  def addData(data: WasmData): Unit = _data += data
   def addGlobal(typ: WasmGlobal): Unit = _globals += typ
   def addExport(exprt: WasmExport): Unit = _exports += exprt
   def setStartFunction(startFunction: WasmFunctionName): Unit = _startFunction = Some(startFunction)
@@ -298,6 +311,7 @@ class WasmModule(
   def imports = _imports.toList
   def definedFunctions = _definedFunctions.toList
   def tags: List[WasmTag] = _tags.toList
+  def data: List[WasmData] = _data.toList
   def globals = _globals.toList
   def exports = _exports.toList
   def startFunction: Option[WasmFunctionName] = _startFunction


### PR DESCRIPTION
close https://github.com/tanishiking/scala-wasm/issues/18

- Add a passive data segment that stores the concatenated string (encoded in UTF-16LE)
  -  `(data $string___data "\6e\00\61\00..."))`
- `getConstantStringInstr` call a `stringLiteral` helper function
- `stringLiteral` helper function does
  - Check if the string literal is found in a global cache (`array of anyref`)
  - if not found, gen i16 array using `array.new_data` and construct JS string using `createStringFromData` helper function, and cache it.