### PR TITLE
Honor some of the linker config options to emit less stuff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         run: sbt scalajs-test-suite/Test/fastLinkJS
       - name: Run the Scala.js test suite
         run: sbt scalajs-test-suite/test
+      - name: Link and run the Scala.js test suite with fullLinkJS
+        run: sbt 'set Global/scalaJSStage := FullOptStage' scalajs-test-suite/test
 
       # Make sure we can emit the .wat file without crashing
       - name: Link the Scala.js test suite with PrettyPrint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,9 @@ jobs:
       - name: Run the Scala.js test suite
         run: sbt scalajs-test-suite/test
 
+      # Make sure we can emit the .wat file without crashing
+      - name: Link the Scala.js test suite with PrettyPrint
+        run: sbt 'set `scalajs-test-suite`/scalaJSLinkerConfig ~= { _.withPrettyPrint(true) }' scalajs-test-suite/Test/fastLinkJS
+
       - name: Format
         run: sbt scalafmtCheckAll

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ You can build and run it like any other Scala.js project from sbt:
 You may want to look at the output in `sample/target/scala-2.12/sample-fastopt/` to convince yourself that it was compiled to WebAssembly.
 
 In that directory, you will also find a `main.wat` file, which is not used for execution.
-It contains the WebAsembly Text Format representation of `main.wasm`, for debugging purposes.
+It contains the WebAsembly Text Format representation of `main.wasm`, for exploratory and debugging purposes.
+This is only true by default for the `sample`.
 
 :warning: If you modify the linker code, you need to `reload` and `sample/clean` for your changes to take effect on the sample.
 
@@ -59,6 +60,9 @@ Run the unit test suite with `tests/test`.
   - Add a file under `test-suite`
   - Add a test case to `tests/src/test/scala/tests/TestSuites.scala`
 
+By default, `.wat` files are not generated, as they are quite big (several hundreds of KB for most of the tests).
+You can enable them by adding `withPrettyPrint(true)` to the linker configuration in `tests/src/test/scala/tests/CoreTests.scala`.
+
 ### Scala.js integration test suite
 
 Run the entire Scala.js test suite, linked with the WebAssembly backend, with:
@@ -72,6 +76,13 @@ Since recompiling the test suite from scratch every time is slow, you can replac
 
 ```
 $ rm -r scalajs-test-suite/target/scala-2.12/scalajs-test-suite-test-fastopt/
+```
+
+By default, `.wat` files are not generated for the Scala.js test suite, as they are very big (they exceed 100 MB).
+It is usually easier to minimize an issue in `sample/test`, but if you really want the big `.wat` file for the Scala.js test suite, you can enable it with
+
+```scala
+> set `scalajs-test-suite`/scalaJSLinkerConfig ~= { _.withPrettyPrint(true) }
 ```
 
 ### Debugging tools

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,9 @@ lazy val sample = project
   .enablePlugins(WasmLinkerPlugin, ScalaJSJUnitPlugin)
   .settings(
     scalaVersion := scalaV,
-    scalaJSUseMainModuleInitializer := true
+    scalaJSUseMainModuleInitializer := true,
+    // Emit .wat files for exploratory and debugging purposes
+    scalaJSLinkerConfig ~= { _.withPrettyPrint(true) },
   )
 
 lazy val testSuite = project

--- a/wasm/src/main/scala/WebAssemblyLinkerBackend.scala
+++ b/wasm/src/main/scala/WebAssemblyLinkerBackend.scala
@@ -106,28 +106,47 @@ final class WebAssemblyLinkerBackend(
     val jsFileName = OutputPatternsImpl.jsFile(linkerConfig.outputPatterns, moduleID)
     val loaderJSFileName = OutputPatternsImpl.jsFile(linkerConfig.outputPatterns, "__loader")
 
-    val textOutput = new converters.WasmTextWriter().write(wasmModule)
-    val textOutputBytes = textOutput.getBytes(StandardCharsets.UTF_8)
-    val binaryOutput = new converters.WasmBinaryWriter(wasmModule).write()
-    val loaderOutput = LoaderContent.bytesContent
-    val jsFileOutput =
-      buildJSFileOutput(onlyModule, loaderJSFileName, wasmFileName, context.allImportedModules)
-    val jsFileOutputBytes = jsFileOutput.getBytes(StandardCharsets.UTF_8)
-
-    val filesToProduce = Set(
-      watFileName,
+    val filesToProduce0 = Set(
       wasmFileName,
       loaderJSFileName,
       jsFileName
     )
+    val filesToProduce =
+      if (linkerConfig.prettyPrint) filesToProduce0 + watFileName
+      else filesToProduce0
+
+    def maybeWriteWatFile(): Future[Unit] = {
+      if (linkerConfig.prettyPrint) {
+        val textOutput = new converters.WasmTextWriter().write(wasmModule)
+        val textOutputBytes = textOutput.getBytes(StandardCharsets.UTF_8)
+        outputImpl.writeFull(watFileName, ByteBuffer.wrap(textOutputBytes))
+      } else {
+        Future.unit
+      }
+    }
+
+    def writeWasmFile(): Future[Unit] = {
+      val binaryOutput = new converters.WasmBinaryWriter(wasmModule).write()
+      outputImpl.writeFull(wasmFileName, ByteBuffer.wrap(binaryOutput))
+    }
+
+    def writeLoaderFile(): Future[Unit] =
+      outputImpl.writeFull(loaderJSFileName, ByteBuffer.wrap(LoaderContent.bytesContent))
+
+    def writeJSFile(): Future[Unit] = {
+      val jsFileOutput =
+        buildJSFileOutput(onlyModule, loaderJSFileName, wasmFileName, context.allImportedModules)
+      val jsFileOutputBytes = jsFileOutput.getBytes(StandardCharsets.UTF_8)
+      outputImpl.writeFull(jsFileName, ByteBuffer.wrap(jsFileOutputBytes))
+    }
 
     for {
       existingFiles <- outputImpl.listFiles()
       _ <- Future.sequence(existingFiles.filterNot(filesToProduce).map(outputImpl.delete(_)))
-      _ <- outputImpl.writeFull(watFileName, ByteBuffer.wrap(textOutputBytes))
-      _ <- outputImpl.writeFull(wasmFileName, ByteBuffer.wrap(binaryOutput))
-      _ <- outputImpl.writeFull(loaderJSFileName, ByteBuffer.wrap(loaderOutput))
-      _ <- outputImpl.writeFull(jsFileName, ByteBuffer.wrap(jsFileOutputBytes))
+      _ <- maybeWriteWatFile()
+      _ <- writeWasmFile()
+      _ <- writeLoaderFile()
+      _ <- writeJSFile()
     } yield {
       val reportModule = new ReportImpl.ModuleImpl(
         moduleID,

--- a/wasm/src/main/scala/WebAssemblyLinkerBackend.scala
+++ b/wasm/src/main/scala/WebAssemblyLinkerBackend.scala
@@ -126,7 +126,8 @@ final class WebAssemblyLinkerBackend(
     }
 
     def writeWasmFile(): Future[Unit] = {
-      val binaryOutput = new converters.WasmBinaryWriter(wasmModule).write()
+      val emitDebugInfo = !linkerConfig.minify
+      val binaryOutput = new converters.WasmBinaryWriter(wasmModule, emitDebugInfo).write()
       outputImpl.writeFull(wasmFileName, ByteBuffer.wrap(binaryOutput))
     }
 

--- a/wasm/src/main/scala/converters/WasmBinaryWriter.scala
+++ b/wasm/src/main/scala/converters/WasmBinaryWriter.scala
@@ -14,7 +14,7 @@ import wasm.wasm4s.Types.WasmHeapType.Func
 import wasm.wasm4s.Types.WasmHeapType.Simple
 import wasm.wasm4s.WasmInstr.END
 
-final class WasmBinaryWriter(module: WasmModule) {
+final class WasmBinaryWriter(module: WasmModule, emitDebugInfo: Boolean) {
   import WasmBinaryWriter._
 
   private val allTypeDefinitions: List[WasmTypeDefinition[_ <: WasmTypeName]] = {
@@ -103,7 +103,9 @@ final class WasmBinaryWriter(module: WasmModule) {
       writeSection(fullOutput, SectionDataCount)(writeDataCountSection(_))
     writeSection(fullOutput, SectionCode)(writeCodeSection(_))
     writeSection(fullOutput, SectionData)(writeDataSection(_))
-    writeCustomSection(fullOutput, "name")(writeNameCustomSection(_))
+
+    if (emitDebugInfo)
+      writeCustomSection(fullOutput, "name")(writeNameCustomSection(_))
 
     fullOutput.result()
   }


### PR DESCRIPTION
* Do not emit `.wat` files unless `withPrettyPrint(true)`
* Do not emit the `"name"` section in the `.wasm` files under `fullLinkJS`
