### PR TITLE
Refactoring: Simplify our model of WebAssembly.

### DIFF
--- a/wasm/src/main/scala/converters/WasmBinaryWriter.scala
+++ b/wasm/src/main/scala/converters/WasmBinaryWriter.scala
@@ -397,49 +397,49 @@ final class WasmBinaryWriter(module: WasmModule, emitDebugInfo: Boolean) {
       case instr: WasmLabelInstr =>
         writeLabelIdx(buf, instr.labelArgument)
       case instr: WasmFuncInstr =>
-        writeFuncIdx(buf, instr.funcArgument.value)
+        writeFuncIdx(buf, instr.funcArgument)
       case instr: WasmTypeInstr =>
-        writeTypeIdx(buf, instr.typeArgument.value)
+        writeTypeIdx(buf, instr.typeArgument)
       case instr: WasmTagInstr =>
-        writeTagIdx(buf, instr.tagArgument.value)
+        writeTagIdx(buf, instr.tagArgument)
       case instr: WasmLocalInstr =>
-        writeLocalIdx(buf, instr.localArgument.value)
+        writeLocalIdx(buf, instr.localArgument)
       case instr: WasmGlobalInstr =>
-        writeGlobalIdx(buf, instr.globalArgument.value)
+        writeGlobalIdx(buf, instr.globalArgument)
       case instr: WasmHeapTypeInstr =>
-        writeHeapType(buf, instr.heapTypeArgument.value)
+        writeHeapType(buf, instr.heapTypeArgument)
       case instr: WasmRefTypeInstr =>
         writeHeapType(buf, instr.refTypeArgument.heapType)
       case instr: WasmStructFieldInstr =>
-        writeTypeIdx(buf, instr.structTypeIdx.value)
+        writeTypeIdx(buf, instr.structTypeName)
         buf.u32(instr.fieldIdx.value)
 
       // Specific instructions with unique-ish shapes
 
-      case I32_CONST(v) => buf.i32(v.value)
-      case I64_CONST(v) => buf.i64(v.value)
-      case F32_CONST(v) => buf.f32(v.value)
-      case F64_CONST(v) => buf.f64(v.value)
+      case I32_CONST(v) => buf.i32(v)
+      case I64_CONST(v) => buf.i64(v)
+      case F32_CONST(v) => buf.f32(v)
+      case F64_CONST(v) => buf.f64(v)
 
       case BR_TABLE(labelIdxVector, defaultLabelIdx) =>
-        buf.vec(labelIdxVector.value)(writeLabelIdx(buf, _))
+        buf.vec(labelIdxVector)(writeLabelIdx(buf, _))
         writeLabelIdx(buf, defaultLabelIdx)
 
       case TRY_TABLE(blockType, clauses, _) =>
         writeBlockType(buf, blockType)
-        buf.vec(clauses.value) { clause =>
+        buf.vec(clauses) { clause =>
           buf.byte(clause.opcode.toByte)
-          clause.tag.foreach(tag => writeTagIdx(buf, tag.value))
+          clause.tag.foreach(tag => writeTagIdx(buf, tag))
           writeLabelIdx(buf, clause.label)
         }
 
       case ARRAY_NEW_DATA(typeIdx, dataIdx) =>
-        writeTypeIdx(buf, typeIdx.value)
-        writeDataIdx(buf, dataIdx.value)
+        writeTypeIdx(buf, typeIdx)
+        writeDataIdx(buf, dataIdx)
 
       case ARRAY_NEW_FIXED(typeIdx, length) =>
-        writeTypeIdx(buf, typeIdx.value)
-        buf.u32(length.value)
+        writeTypeIdx(buf, typeIdx)
+        buf.u32(length)
 
       case BR_ON_CAST(labelIdx, from, to) =>
         writeBrOnCast(labelIdx, from, to)

--- a/wasm/src/main/scala/converters/WasmBinaryWriter.scala
+++ b/wasm/src/main/scala/converters/WasmBinaryWriter.scala
@@ -63,7 +63,7 @@ final class WasmBinaryWriter(module: WasmModule, emitDebugInfo: Boolean) {
   }
 
   private var localIdxValues: Option[Map[WasmLocalName, Int]] = None
-  private var labelsInScope: List[Option[WasmImmediate.LabelIdx]] = Nil
+  private var labelsInScope: List[Option[WasmLabelName]] = Nil
 
   private def withLocalIdxValues(values: Map[WasmLocalName, Int])(f: => Unit): Unit = {
     val saved = localIdxValues
@@ -333,7 +333,7 @@ final class WasmBinaryWriter(module: WasmModule, emitDebugInfo: Boolean) {
     }
   }
 
-  private def writeLabelIdx(buf: Buffer, labelIdx: WasmImmediate.LabelIdx): Unit = {
+  private def writeLabelIdx(buf: Buffer, labelIdx: WasmLabelName): Unit = {
     val relativeNumber = labelsInScope.indexOf(Some(labelIdx))
     if (relativeNumber < 0)
       throw new IllegalStateException(s"Cannot find $labelIdx in scope")
@@ -376,7 +376,7 @@ final class WasmBinaryWriter(module: WasmModule, emitDebugInfo: Boolean) {
     import WasmInstr._
 
     def writeBrOnCast(
-        labelIdx: WasmImmediate.LabelIdx,
+        labelIdx: WasmLabelName,
         from: WasmRefType,
         to: WasmRefType
     ): Unit = {

--- a/wasm/src/main/scala/converters/WasmBinaryWriter.scala
+++ b/wasm/src/main/scala/converters/WasmBinaryWriter.scala
@@ -9,7 +9,7 @@ import java.io.ByteArrayOutputStream
 import wasm.wasm4s._
 import wasm.wasm4s.Names._
 import wasm.wasm4s.Types._
-import wasm.wasm4s.WasmInstr.END
+import wasm.wasm4s.WasmInstr.{BlockType, END}
 
 final class WasmBinaryWriter(module: WasmModule, emitDebugInfo: Boolean) {
   import WasmBinaryWriter._
@@ -448,9 +448,7 @@ final class WasmBinaryWriter(module: WasmModule, emitDebugInfo: Boolean) {
     }
   }
 
-  private def writeBlockType(buf: Buffer, blockType: WasmImmediate.BlockType): Unit = {
-    import WasmImmediate._
-
+  private def writeBlockType(buf: Buffer, blockType: BlockType): Unit = {
     blockType match {
       case BlockType.ValueType(None)        => buf.byte(0x40)
       case BlockType.ValueType(Some(typ))   => writeType(buf, typ)

--- a/wasm/src/main/scala/converters/WasmBinaryWriter.scala
+++ b/wasm/src/main/scala/converters/WasmBinaryWriter.scala
@@ -382,10 +382,6 @@ final class WasmBinaryWriter(module: WasmModule, emitDebugInfo: Boolean) {
       case F32(value) => buf.f32(value)
       case F64(value) => buf.f64(value)
 
-      case MemArg(offset, align) =>
-        buf.u32(offset.toInt)
-        buf.u32(align.toInt)
-
       case BlockType.ValueType(None)        => buf.byte(0x40)
       case BlockType.ValueType(Some(typ))   => writeType(buf, typ)
       case BlockType.FunctionType(typeName) => writeTypeIdxs33(buf, typeName)

--- a/wasm/src/main/scala/converters/WasmBinaryWriter.scala
+++ b/wasm/src/main/scala/converters/WasmBinaryWriter.scala
@@ -391,7 +391,6 @@ final class WasmBinaryWriter(module: WasmModule, emitDebugInfo: Boolean) {
       case LabelIdxVector(value) => buf.vec(value)(writeLabelIdx(buf, _))
       case TypeIdx(value)        => writeTypeIdx(buf, value)
       case DataIdx(value)        => writeDataIdx(buf, value)
-      case TableIdx(value)       => ???
       case TagIdx(value)         => writeTagIdx(buf, value)
       case LocalIdx(value)       => writeLocalIdx(buf, value)
       case GlobalIdx(value)      => writeGlobalIdx(buf, value)

--- a/wasm/src/main/scala/converters/WasmTextWriter.scala
+++ b/wasm/src/main/scala/converters/WasmTextWriter.scala
@@ -328,9 +328,8 @@ class WasmTextWriter {
         b.appendElement(s"$$${i.toString}")
       case WasmImmediate.LabelIdxVector(indices) =>
         indices.foreach(i => b.appendElement("$" + i.value))
-      case WasmImmediate.TagIdx(name)    => b.appendElement(name.show)
-      case WasmImmediate.DataIdx(name)   => b.appendElement(name.show)
-      case WasmImmediate.TableIdx(value) => ???
+      case WasmImmediate.TagIdx(name)  => b.appendElement(name.show)
+      case WasmImmediate.DataIdx(name) => b.appendElement(name.show)
       case WasmImmediate.CatchClauseVector(clauses) =>
         for (clause <- clauses) {
           b.appendElement("(" + clause.mnemonic)

--- a/wasm/src/main/scala/converters/WasmTextWriter.scala
+++ b/wasm/src/main/scala/converters/WasmTextWriter.scala
@@ -313,8 +313,8 @@ class WasmTextWriter {
     }
   }
 
-  private def writeLabelIdx(labelIdx: WasmImmediate.LabelIdx)(implicit b: WatBuilder): Unit =
-    b.appendElement(s"$$${labelIdx.value}")
+  private def writeLabelIdx(labelIdx: WasmLabelName)(implicit b: WatBuilder): Unit =
+    b.appendElement(labelIdx.show)
 
   private def writeInstr(instr: WasmInstr)(implicit b: WatBuilder): Unit = {
     instr match {

--- a/wasm/src/main/scala/converters/WasmTextWriter.scala
+++ b/wasm/src/main/scala/converters/WasmTextWriter.scala
@@ -303,11 +303,11 @@ class WasmTextWriter {
     else v.toString()
   }
 
-  private def writeBlockType(blockType: WasmImmediate.BlockType)(implicit b: WatBuilder): Unit = {
+  private def writeBlockType(blockType: BlockType)(implicit b: WatBuilder): Unit = {
     blockType match {
-      case WasmImmediate.BlockType.FunctionType(name) =>
+      case BlockType.FunctionType(name) =>
         b.appendElement(s"(type ${name.show})")
-      case WasmImmediate.BlockType.ValueType(optTy) =>
+      case BlockType.ValueType(optTy) =>
         for (ty <- optTy)
           b.sameLineList("result", writeType(ty))
     }

--- a/wasm/src/main/scala/converters/WasmTextWriter.scala
+++ b/wasm/src/main/scala/converters/WasmTextWriter.scala
@@ -328,8 +328,9 @@ class WasmTextWriter {
         b.appendElement(s"$$${i.toString}")
       case WasmImmediate.LabelIdxVector(indices) =>
         indices.foreach(i => b.appendElement("$" + i.value))
-      case WasmImmediate.TagIdx(name)  => b.appendElement(name.show)
-      case WasmImmediate.DataIdx(name) => b.appendElement(name.show)
+      case WasmImmediate.TagIdx(name)    => b.appendElement(name.show)
+      case WasmImmediate.DataIdx(name)   => b.appendElement(name.show)
+      case WasmImmediate.TableIdx(value) => ???
       case WasmImmediate.CatchClauseVector(clauses) =>
         for (clause <- clauses) {
           b.appendElement("(" + clause.mnemonic)
@@ -341,9 +342,6 @@ class WasmTextWriter {
         throw new UnsupportedOperationException(
           s"CastFlags $i must be handled directly in the instruction $instr"
         )
-      case _ =>
-        println(i)
-        ???
     }
   }
 

--- a/wasm/src/main/scala/converters/WasmTextWriter.scala
+++ b/wasm/src/main/scala/converters/WasmTextWriter.scala
@@ -349,52 +349,52 @@ class WasmTextWriter {
       case instr: WasmLabelInstr =>
         writeLabelIdx(instr.labelArgument)
       case instr: WasmFuncInstr =>
-        b.appendElement(instr.funcArgument.value.show)
+        b.appendElement(instr.funcArgument.show)
       case instr: WasmTypeInstr =>
-        b.appendElement(instr.typeArgument.value.show)
+        b.appendElement(instr.typeArgument.show)
       case instr: WasmTagInstr =>
-        b.appendElement(instr.tagArgument.value.show)
+        b.appendElement(instr.tagArgument.show)
       case instr: WasmLocalInstr =>
-        b.appendElement(instr.localArgument.value.show)
+        b.appendElement(instr.localArgument.show)
       case instr: WasmGlobalInstr =>
-        b.appendElement(instr.globalArgument.value.show)
+        b.appendElement(instr.globalArgument.show)
       case instr: WasmHeapTypeInstr =>
-        writeHeapType(instr.heapTypeArgument.value)
+        writeHeapType(instr.heapTypeArgument)
       case instr: WasmRefTypeInstr =>
         writeType(instr.refTypeArgument)
       case instr: WasmStructFieldInstr =>
-        b.appendElement(instr.structTypeIdx.value.show)
+        b.appendElement(instr.structTypeName.show)
         b.appendElement(instr.fieldIdx.value.toString())
 
       // Specific instructions with unique-ish shapes
 
-      case I32_CONST(v) => b.appendElement(v.value.toString())
-      case I64_CONST(v) => b.appendElement(v.value.toString())
-      case F32_CONST(v) => b.appendElement(floatString(v.value.toDouble))
-      case F64_CONST(v) => b.appendElement(floatString(v.value))
+      case I32_CONST(v) => b.appendElement(v.toString())
+      case I64_CONST(v) => b.appendElement(v.toString())
+      case F32_CONST(v) => b.appendElement(floatString(v.toDouble))
+      case F64_CONST(v) => b.appendElement(floatString(v))
 
       case BR_TABLE(labelIdxVector, defaultLabelIdx) =>
-        labelIdxVector.value.foreach(writeLabelIdx(_))
+        labelIdxVector.foreach(writeLabelIdx(_))
         writeLabelIdx(defaultLabelIdx)
 
       case TRY_TABLE(blockType, clauses, _) =>
         writeBlockType(blockType)
-        for (clause <- clauses.value) {
+        for (clause <- clauses) {
           b.sameLineList(
             clause.mnemonic, {
-              clause.tag.foreach(tag => b.appendElement(tag.value.show))
+              clause.tag.foreach(tag => b.appendElement(tag.show))
               writeLabelIdx(clause.label)
             }
           )
         }
 
       case ARRAY_NEW_DATA(typeIdx, dataIdx) =>
-        b.appendElement(typeIdx.value.show)
-        b.appendElement(dataIdx.value.show)
+        b.appendElement(typeIdx.show)
+        b.appendElement(dataIdx.show)
 
       case ARRAY_NEW_FIXED(typeIdx, length) =>
-        b.appendElement(typeIdx.value.show)
-        b.appendElement(Integer.toUnsignedString(length.value))
+        b.appendElement(typeIdx.show)
+        b.appendElement(Integer.toUnsignedString(length))
 
       case BR_ON_CAST(labelIdx, from, to) =>
         writeLabelIdx(labelIdx)

--- a/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
+++ b/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
@@ -37,7 +37,7 @@ object HelperFunctions {
 
   private def genStringLiteral()(implicit ctx: WasmContext): Unit = {
     import WasmTypeName.WasmArrayTypeName
-    import WasmImmediate._
+
     val fctx = WasmFunctionContext(
       WasmFunctionName.stringLiteral,
       List("offset" -> WasmInt32, "size" -> WasmInt32, "stringIndex" -> WasmInt32),
@@ -74,7 +74,6 @@ object HelperFunctions {
 
   /** `createStringFromData: (ref array u16) -> (ref any)` (representing a `string`). */
   private def genCreateStringFromData()(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
     import WasmTypeName.WasmArrayTypeName
 
     val dataType = WasmRefType(WasmArrayTypeName.i16Array)
@@ -152,7 +151,6 @@ object HelperFunctions {
     *   [[https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Class.html#getName()]]
     */
   private def genTypeDataName()(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
     import WasmTypeName._
 
     val typeDataType = WasmRefType(WasmStructType.typeData.name)
@@ -291,7 +289,6 @@ object HelperFunctions {
     * with the non-null case as a fast-path.
     */
   private def genCreateClassOf()(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
     import WasmTypeName.WasmStructTypeName
 
     val typeDataType = WasmRefType(WasmStructType.typeData.name)
@@ -412,7 +409,6 @@ object HelperFunctions {
     * performance-sensitive.
     */
   private def genGetClassOf()(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
     import WasmTypeName.WasmStructTypeName
 
     val typeDataType = WasmRefType(WasmStructType.typeData.name)
@@ -446,7 +442,6 @@ object HelperFunctions {
     * must be be strictly positive.
     */
   private def genArrayTypeData()(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
     import WasmTypeName._
 
     val typeDataType = WasmRefType(WasmStructType.typeData.name)
@@ -549,7 +544,6 @@ object HelperFunctions {
     * [[https://lampwww.epfl.ch/~doeraene/sjsir-semantics/#sec-sjsir-createclassdataof]].
     */
   private def genIsInstance()(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
     import WasmTypeName.WasmStructTypeName
     import WasmFieldIdx.typeData._
 
@@ -719,8 +713,6 @@ object HelperFunctions {
     * This is the underlying func for the `isAssignableFrom()` closure inside class data objects.
     */
   private def genIsAssignableFromExternal()(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
-
     val typeDataType = WasmRefType(WasmStructType.typeData.name)
 
     val fctx = WasmFunctionContext(
@@ -753,7 +745,6 @@ object HelperFunctions {
     * Specified by `java.lang.Class.isAssignableFrom(Class)`.
     */
   private def genIsAssignableFrom()(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
     import WasmTypeName._
     import WasmFieldIdx.typeData._
 
@@ -913,7 +904,6 @@ object HelperFunctions {
     * This is the underlying func for the `getComponentType()` closure inside class data objects.
     */
   private def genGetComponentType()(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
     import WasmTypeName.WasmStructTypeName
 
     val typeDataType = WasmRefType(WasmStructType.typeData.name)
@@ -952,7 +942,6 @@ object HelperFunctions {
     * This is the underlying func for the `newArrayOfThisClass()` closure inside class data objects.
     */
   private def genNewArrayOfThisClass()(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
     import WasmTypeName.WasmStructTypeName
 
     val typeDataType = WasmRefType(WasmStructType.typeData.name)
@@ -1033,7 +1022,6 @@ object HelperFunctions {
     * [[https://www.scala-js.org/doc/semantics.html#getclass]].
     */
   private def genAnyGetClass()(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
     import WasmTypeName.WasmStructTypeName
 
     val typeDataType = WasmRefType(WasmStructType.typeData.name)
@@ -1185,7 +1173,6 @@ object HelperFunctions {
     * lengths, lengthIndex - 1)`.
     */
   def genNewArrayObject()(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
     import WasmTypeName._
     import WasmFieldIdx.typeData._
 
@@ -1374,7 +1361,6 @@ object HelperFunctions {
     * See https://github.com/tanishiking/scala-wasm/issues/27#issuecomment-2008252049
     */
   def genInstanceTest(clazz: LinkedClass)(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
     assert(clazz.kind == ClassKind.Interface)
 
     val fctx = WasmFunctionContext(
@@ -1429,7 +1415,6 @@ object HelperFunctions {
     * called on the class instance.
     */
   def genCloneFunction(clazz: LinkedClass)(implicit ctx: WasmContext): Unit = {
-    import WasmImmediate._
     val info = ctx.getClassInfo(clazz.name.name)
     if (info.ancestors.contains(IRNames.CloneableClass) && !info.isAbstract) {
       val heapType =

--- a/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
+++ b/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
@@ -77,7 +77,7 @@ object HelperFunctions {
     import WasmImmediate._
     import WasmTypeName.WasmArrayTypeName
 
-    val dataType = WasmRefType(WasmHeapType.Type(WasmArrayTypeName.i16Array))
+    val dataType = WasmRefType(WasmArrayTypeName.i16Array)
 
     val fctx = WasmFunctionContext(
       WasmFunctionName.createStringFromData,
@@ -155,8 +155,8 @@ object HelperFunctions {
     import WasmImmediate._
     import WasmTypeName._
 
-    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
-    val nameDataType = WasmRefType(WasmHeapType.Type(WasmArrayTypeName.i16Array))
+    val typeDataType = WasmRefType(WasmStructType.typeData.name)
+    val nameDataType = WasmRefType(WasmArrayTypeName.i16Array)
 
     val u16ArrayIdx = TypeIdx(WasmArrayTypeName.i16Array)
 
@@ -296,7 +296,7 @@ object HelperFunctions {
     import WasmImmediate._
     import WasmTypeName.WasmStructTypeName
 
-    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
+    val typeDataType = WasmRefType(WasmStructType.typeData.name)
 
     val fctx = WasmFunctionContext(
       WasmFunctionName.createClassOf,
@@ -419,7 +419,7 @@ object HelperFunctions {
     import WasmImmediate._
     import WasmTypeName.WasmStructTypeName
 
-    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
+    val typeDataType = WasmRefType(WasmStructType.typeData.name)
 
     val fctx = WasmFunctionContext(
       WasmFunctionName.getClassOf,
@@ -453,10 +453,8 @@ object HelperFunctions {
     import WasmImmediate._
     import WasmTypeName._
 
-    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
-    val objectVTableType = WasmRefType(
-      WasmHeapType.Type(WasmTypeName.WasmStructTypeName.ObjectVTable)
-    )
+    val typeDataType = WasmRefType(WasmStructType.typeData.name)
+    val objectVTableType = WasmRefType(WasmTypeName.WasmStructTypeName.ObjectVTable)
 
     /* Array classes extend Cloneable, Serializable and Object.
      * Filter out the ones that do not have run-time type info at all, as
@@ -492,7 +490,7 @@ object HelperFunctions {
         instrs += LOCAL_GET(typeDataParam)
 
         // typeData := new typeData(...)
-        instrs += REF_NULL(HeapType(WasmHeapType.Simple.None)) // nameData
+        instrs += REF_NULL(HeapType(WasmHeapType.None)) // nameData
         instrs += I32_CONST(I32(KindArray)) // kind = KindArray
         instrs += I32_CONST(I32(0)) // specialInstanceTypes = 0
 
@@ -505,11 +503,11 @@ object HelperFunctions {
         )
 
         instrs += LOCAL_GET(typeDataParam) // componentType
-        instrs += REF_NULL(HeapType(WasmHeapType.Simple.None)) // name
-        instrs += REF_NULL(HeapType(WasmHeapType.Simple.None)) // classOf
-        instrs += REF_NULL(HeapType(WasmHeapType.Simple.None)) // arrayOf
+        instrs += REF_NULL(HeapType(WasmHeapType.None)) // name
+        instrs += REF_NULL(HeapType(WasmHeapType.None)) // classOf
+        instrs += REF_NULL(HeapType(WasmHeapType.None)) // arrayOf
         instrs += REF_NULL(
-          HeapType(WasmHeapType.Type(ctx.cloneFunctionTypeName))
+          HeapType(WasmHeapType(ctx.cloneFunctionTypeName))
         ) // clone
         instrs ++= ctx
           .calculateGlobalVTable(IRNames.ObjectClass)
@@ -561,14 +559,12 @@ object HelperFunctions {
     import WasmTypeName.WasmStructTypeName
     import WasmFieldName.typeData._
 
-    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
-    val objectRefType = WasmRefType(
-      WasmHeapType.Type(WasmTypeName.WasmStructTypeName.forClass(IRNames.ObjectClass))
-    )
+    val typeDataType = WasmRefType(WasmStructType.typeData.name)
+    val objectRefType = WasmRefType(WasmTypeName.WasmStructTypeName.forClass(IRNames.ObjectClass))
 
     val fctx = WasmFunctionContext(
       WasmFunctionName.isInstance,
-      List("typeData" -> typeDataType, "value" -> WasmAnyRef),
+      List("typeData" -> typeDataType, "value" -> WasmRefType.anyref),
       List(WasmInt32)
     )
 
@@ -613,7 +609,7 @@ object HelperFunctions {
       List(KindBoxedCharacter) -> { () =>
         instrs += LOCAL_GET(valueNonNullLocal)
         val structTypeName = WasmStructTypeName.forClass(SpecialNames.CharBoxClass)
-        instrs += REF_TEST(HeapType(Types.WasmHeapType.Type(structTypeName)))
+        instrs += REF_TEST(HeapType(Types.WasmHeapType(structTypeName)))
       },
       List(KindBoxedByte) -> { () =>
         instrs += LOCAL_GET(valueNonNullLocal)
@@ -630,7 +626,7 @@ object HelperFunctions {
       List(KindBoxedLong) -> { () =>
         instrs += LOCAL_GET(valueNonNullLocal)
         val structTypeName = WasmStructTypeName.forClass(SpecialNames.LongBoxClass)
-        instrs += REF_TEST(HeapType(Types.WasmHeapType.Type(structTypeName)))
+        instrs += REF_TEST(HeapType(Types.WasmHeapType(structTypeName)))
       },
       List(KindBoxedFloat) -> { () =>
         instrs += LOCAL_GET(valueNonNullLocal)
@@ -705,7 +701,7 @@ object HelperFunctions {
         instrs += BR_ON_CAST(
           CastFlags(false, false),
           ourObjectLabel,
-          HeapType(WasmHeapType.Simple.Any),
+          HeapType(WasmHeapType.Any),
           HeapType(objectRefType.heapType)
         )
 
@@ -732,11 +728,11 @@ object HelperFunctions {
   private def genIsAssignableFromExternal()(implicit ctx: WasmContext): Unit = {
     import WasmImmediate._
 
-    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
+    val typeDataType = WasmRefType(WasmStructType.typeData.name)
 
     val fctx = WasmFunctionContext(
       WasmFunctionName.isAssignableFromExternal,
-      List("typeData" -> typeDataType, "from" -> WasmAnyRef),
+      List("typeData" -> typeDataType, "from" -> WasmRefType.anyref),
       List(WasmInt32)
     )
 
@@ -768,7 +764,7 @@ object HelperFunctions {
     import WasmTypeName._
     import WasmFieldName.typeData._
 
-    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
+    val typeDataType = WasmRefType(WasmStructType.typeData.name)
 
     val fctx = WasmFunctionContext(
       WasmFunctionName.isAssignableFrom,
@@ -782,7 +778,7 @@ object HelperFunctions {
 
     val fromAncestorsLocal = fctx.addLocal(
       "fromAncestorsLocal",
-      WasmRefType(WasmHeapType.Type(WasmArrayTypeName.typeDataArray))
+      WasmRefType(WasmArrayTypeName.typeDataArray)
     )
     val lenLocal = fctx.addLocal("len", WasmInt32)
     val iLocal = fctx.addLocal("i", WasmInt32)
@@ -898,12 +894,12 @@ object HelperFunctions {
     * Casts the given value to the given type; subject to undefined behaviors.
     */
   private def genCheckCast()(implicit ctx: WasmContext): Unit = {
-    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
+    val typeDataType = WasmRefType(WasmStructType.typeData.name)
 
     val fctx = WasmFunctionContext(
       WasmFunctionName.checkCast,
-      List("typeData" -> typeDataType, "value" -> WasmAnyRef),
-      List(WasmAnyRef)
+      List("typeData" -> typeDataType, "value" -> WasmRefType.anyref),
+      List(WasmRefType.anyref)
     )
 
     val List(typeDataParam, valueParam) = fctx.paramIndices
@@ -927,12 +923,12 @@ object HelperFunctions {
     import WasmImmediate._
     import WasmTypeName.WasmStructTypeName
 
-    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
+    val typeDataType = WasmRefType(WasmStructType.typeData.name)
 
     val fctx = WasmFunctionContext(
       WasmFunctionName.getComponentType,
       List("typeData" -> typeDataType),
-      List(WasmRefNullType(WasmHeapType.ClassType))
+      List(WasmRefType.nullable(WasmHeapType.ClassType))
     )
 
     val List(typeDataParam) = fctx.paramIndices
@@ -966,12 +962,12 @@ object HelperFunctions {
     import WasmImmediate._
     import WasmTypeName.WasmStructTypeName
 
-    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
-    val i32ArrayType = WasmRefType(WasmHeapType.Type(WasmTypeName.WasmArrayTypeName.i32Array))
+    val typeDataType = WasmRefType(WasmStructType.typeData.name)
+    val i32ArrayType = WasmRefType(WasmTypeName.WasmArrayTypeName.i32Array)
 
     val fctx = WasmFunctionContext(
       WasmFunctionName.newArrayOfThisClass,
-      List("typeData" -> typeDataType, "lengths" -> WasmAnyRef),
+      List("typeData" -> typeDataType, "lengths" -> WasmRefType.anyref),
       List(WasmRefType(WasmHeapType.ObjectType))
     )
 
@@ -1047,12 +1043,12 @@ object HelperFunctions {
     import WasmImmediate._
     import WasmTypeName.WasmStructTypeName
 
-    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
+    val typeDataType = WasmRefType(WasmStructType.typeData.name)
 
     val fctx = WasmFunctionContext(
       WasmFunctionName.anyGetClass,
       List("value" -> WasmRefType.any),
-      List(WasmRefNullType(WasmHeapType.ClassType))
+      List(WasmRefType.nullable(WasmHeapType.ClassType))
     )
 
     val List(valueParam) = fctx.paramIndices
@@ -1067,7 +1063,7 @@ object HelperFunctions {
     def getHijackedClassTypeDataInstr(className: IRNames.ClassName): WasmInstr =
       GLOBAL_GET(GlobalIdx(WasmGlobalName.forVTable(className)))
 
-    fctx.block(WasmRefNullType(WasmHeapType.ClassType)) { nonNullClassOfLabel =>
+    fctx.block(WasmRefType.nullable(WasmHeapType.ClassType)) { nonNullClassOfLabel =>
       fctx.block(typeDataType) { gotTypeDataLabel =>
         fctx.block(WasmRefType(WasmHeapType.ObjectType)) { ourObjectLabel =>
           // if value is our object, jump to $ourObject
@@ -1075,7 +1071,7 @@ object HelperFunctions {
           instrs += BR_ON_CAST(
             CastFlags(false, false),
             ourObjectLabel,
-            WasmImmediate.HeapType(WasmHeapType.Simple.Any),
+            WasmImmediate.HeapType(WasmHeapType.Any),
             WasmImmediate.HeapType(WasmHeapType.ObjectType)
           )
 
@@ -1202,13 +1198,13 @@ object HelperFunctions {
     import WasmTypeName._
     import WasmFieldName.typeData._
 
-    val typeDataType = WasmRefType(WasmHeapType.Type(WasmStructType.typeData.name))
-    val i32ArrayType = WasmRefType(WasmHeapType.Type(WasmTypeName.WasmArrayTypeName.i32Array))
-    val objectVTableType = WasmRefType(WasmHeapType.Type(WasmStructTypeName.ObjectVTable))
+    val typeDataType = WasmRefType(WasmStructType.typeData.name)
+    val i32ArrayType = WasmRefType(WasmTypeName.WasmArrayTypeName.i32Array)
+    val objectVTableType = WasmRefType(WasmStructTypeName.ObjectVTable)
     val arrayTypeDataType = objectVTableType
-    val itablesType = WasmRefNullType(WasmHeapType.Type(WasmArrayType.itables.name))
+    val itablesType = WasmRefType.nullable(WasmArrayType.itables.name)
     val nonNullObjectType = WasmRefType(WasmHeapType.ObjectType)
-    val anyArrayType = WasmRefType(WasmHeapType.Type(WasmArrayTypeName.anyArray))
+    val anyArrayType = WasmRefType(WasmArrayTypeName.anyArray)
 
     val fctx = WasmFunctionContext(
       WasmFunctionName.newArrayObject,
@@ -1269,7 +1265,7 @@ object HelperFunctions {
     // Load the vtable and itable or the resulting array on the stack
     instrs += LOCAL_GET(arrayTypeDataParam) // vtable
     // TODO: this should not be null because of Serializable and Cloneable
-    instrs += REF_NULL(HeapType(Types.WasmHeapType.Type(WasmArrayType.itables.name))) // itable
+    instrs += REF_NULL(HeapType(Types.WasmHeapType(WasmArrayType.itables.name))) // itable
 
     // Load the first length
     instrs += LOCAL_GET(lengthsParam)
@@ -1392,7 +1388,7 @@ object HelperFunctions {
 
     val fctx = WasmFunctionContext(
       Names.WasmFunctionName.instanceTest(clazz.name.name),
-      List("expr" -> WasmAnyRef),
+      List("expr" -> WasmRefType.anyref),
       List(WasmInt32)
     )
     val List(exprParam) = fctx.paramIndices
@@ -1400,16 +1396,16 @@ object HelperFunctions {
     import fctx.instrs
 
     val itables = fctx.addSyntheticLocal(
-      Types.WasmRefNullType(Types.WasmHeapType.Type(WasmArrayType.itables.name))
+      Types.WasmRefType.nullable(WasmArrayType.itables.name)
     )
     val itableIdx = ctx.getItableIdx(clazz.name.name)
-    fctx.block(WasmRefNullType(WasmHeapType.Simple.Any)) { testFail =>
+    fctx.block(WasmRefType.anyref) { testFail =>
       // if expr is not an instance of Object, return false
       instrs += LOCAL_GET(exprParam)
       instrs += BR_ON_CAST_FAIL(
         CastFlags(true, false),
         testFail,
-        HeapType(Types.WasmHeapType.Simple.Any),
+        HeapType(Types.WasmHeapType.Any),
         HeapType(Types.WasmHeapType.ObjectType)
       )
 
@@ -1418,7 +1414,7 @@ object HelperFunctions {
       instrs += LOCAL_SET(itables)
 
       // Dummy return value from the block
-      instrs += REF_NULL(HeapType(WasmHeapType.Simple.Any))
+      instrs += REF_NULL(HeapType(WasmHeapType.Any))
 
       // if the itables is null (no interfaces are implemented)
       instrs += LOCAL_GET(itables)
@@ -1447,7 +1443,7 @@ object HelperFunctions {
     val info = ctx.getClassInfo(clazz.name.name)
     if (info.ancestors.contains(IRNames.CloneableClass) && !info.isAbstract) {
       val heapType =
-        WasmHeapType.Type(WasmTypeName.WasmStructTypeName.forClass(clazz.name.name))
+        WasmHeapType(WasmTypeName.WasmStructTypeName.forClass(clazz.name.name))
       val fctx = WasmFunctionContext(
         Names.WasmFunctionName.clone(clazz.name.name),
         List("from" -> WasmRefType(WasmHeapType.ObjectType)),
@@ -1456,8 +1452,8 @@ object HelperFunctions {
       val List(fromParam) = fctx.paramIndices
       import fctx.instrs
 
-      val from = fctx.addSyntheticLocal(WasmRefNullType(heapType))
-      val result = fctx.addSyntheticLocal(WasmRefNullType(heapType))
+      val from = fctx.addSyntheticLocal(WasmRefType.nullable(heapType))
+      val result = fctx.addSyntheticLocal(WasmRefType.nullable(heapType))
 
       instrs += LOCAL_GET(fromParam)
       instrs += REF_CAST(HeapType(heapType))
@@ -1494,7 +1490,7 @@ object HelperFunctions {
     val fctx = WasmFunctionContext(
       Names.WasmFunctionName.newDefault(className),
       Nil,
-      List(WasmRefType(WasmHeapType.Type(structName)))
+      List(WasmRefType(structName))
     )
 
     import fctx.instrs
@@ -1506,7 +1502,7 @@ object HelperFunctions {
       instrs += GLOBAL_GET(WasmImmediate.GlobalIdx(WasmGlobalName.forITable(className)))
     else
       instrs +=
-        REF_NULL(WasmImmediate.HeapType(WasmHeapType.Type(WasmArrayType.itables.name)))
+        REF_NULL(WasmImmediate.HeapType(WasmHeapType(WasmArrayType.itables.name)))
 
     classInfo.allFieldDefs.foreach { f =>
       val ty = transformType(f.ftpe)

--- a/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
+++ b/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
@@ -609,7 +609,7 @@ object HelperFunctions {
       List(KindBoxedCharacter) -> { () =>
         instrs += LOCAL_GET(valueNonNullLocal)
         val structTypeName = WasmStructTypeName.forClass(SpecialNames.CharBoxClass)
-        instrs += REF_TEST(HeapType(Types.WasmHeapType(structTypeName)))
+        instrs += REF_TEST(WasmRefType(structTypeName))
       },
       List(KindBoxedByte) -> { () =>
         instrs += LOCAL_GET(valueNonNullLocal)
@@ -626,7 +626,7 @@ object HelperFunctions {
       List(KindBoxedLong) -> { () =>
         instrs += LOCAL_GET(valueNonNullLocal)
         val structTypeName = WasmStructTypeName.forClass(SpecialNames.LongBoxClass)
-        instrs += REF_TEST(HeapType(Types.WasmHeapType(structTypeName)))
+        instrs += REF_TEST(WasmRefType(structTypeName))
       },
       List(KindBoxedFloat) -> { () =>
         instrs += LOCAL_GET(valueNonNullLocal)
@@ -699,10 +699,9 @@ object HelperFunctions {
         // Try cast to jl.Object
         instrs += LOCAL_GET(valueNonNullLocal)
         instrs += BR_ON_CAST(
-          CastFlags(false, false),
           ourObjectLabel,
-          HeapType(WasmHeapType.Any),
-          HeapType(objectRefType.heapType)
+          WasmRefType.any,
+          WasmRefType(objectRefType.heapType)
         )
 
         // on cast fail, return false
@@ -747,7 +746,7 @@ object HelperFunctions {
     instrs += LOCAL_GET(fromParam)
     instrs ++= ctx.getConstantStringInstr("__typeData")
     instrs += CALL(FuncIdx(WasmFunctionName.jsSelect))
-    instrs += REF_CAST(HeapType(typeDataType.heapType))
+    instrs += REF_CAST(WasmRefType(typeDataType.heapType))
 
     // delegate to isAssignableFrom
     instrs += CALL(FuncIdx(WasmFunctionName.isAssignableFrom))
@@ -1069,10 +1068,9 @@ object HelperFunctions {
           // if value is our object, jump to $ourObject
           instrs += LOCAL_GET(valueParam)
           instrs += BR_ON_CAST(
-            CastFlags(false, false),
             ourObjectLabel,
-            WasmImmediate.HeapType(WasmHeapType.Any),
-            WasmImmediate.HeapType(WasmHeapType.ObjectType)
+            WasmRefType.any,
+            WasmRefType(WasmHeapType.ObjectType)
           )
 
           // switch(jsValueType(value)) { ... }
@@ -1330,7 +1328,7 @@ object HelperFunctions {
           TypeIdx(WasmStructTypeName.typeData),
           WasmFieldName.typeData.componentTypeIdx
         )
-        instrs += REF_CAST(HeapType(arrayTypeDataType.heapType))
+        instrs += REF_CAST(WasmRefType(arrayTypeDataType.heapType))
         instrs += LOCAL_SET(arrayComponentTypeDataLocal)
 
         // i := 0
@@ -1403,10 +1401,9 @@ object HelperFunctions {
       // if expr is not an instance of Object, return false
       instrs += LOCAL_GET(exprParam)
       instrs += BR_ON_CAST_FAIL(
-        CastFlags(true, false),
         testFail,
-        HeapType(Types.WasmHeapType.Any),
-        HeapType(Types.WasmHeapType.ObjectType)
+        WasmRefType.anyref,
+        WasmRefType(Types.WasmHeapType.ObjectType)
       )
 
       // get itables and store
@@ -1456,7 +1453,7 @@ object HelperFunctions {
       val result = fctx.addSyntheticLocal(WasmRefType.nullable(heapType))
 
       instrs += LOCAL_GET(fromParam)
-      instrs += REF_CAST(HeapType(heapType))
+      instrs += REF_CAST(WasmRefType(heapType))
       instrs += LOCAL_SET(from)
 
       instrs += CALL(FuncIdx(WasmFunctionName.newDefault(clazz.name.name)))

--- a/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
+++ b/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
@@ -146,7 +146,7 @@ object HelperFunctions {
     * value.
     *
     * The computed value is specified by `java.lang.Class.getName()`. See also the documentation on
-    * [[Names.WasmFieldName.typeData.name]] for details.
+    * [[Names.StructFieldIdx.typeData.name]] for details.
     *
     * @see
     *   [[https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Class.html#getName()]]
@@ -176,7 +176,7 @@ object HelperFunctions {
     fctx.block(WasmRefType.any) { alreadyInitializedLabel =>
       // br_on_non_null $alreadyInitialized typeData.name
       instrs += LOCAL_GET(typeDataParam)
-      instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldName.typeData.nameIdx)
+      instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldIdx.typeData.nameIdx)
       instrs += BR_ON_NON_NULL(alreadyInitializedLabel)
 
       // for the STRUCT_SET typeData.name near the end
@@ -184,7 +184,7 @@ object HelperFunctions {
 
       // if typeData.kind == KindArray
       instrs += LOCAL_GET(typeDataParam)
-      instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldName.typeData.kindIdx)
+      instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldIdx.typeData.kindIdx)
       instrs += I32_CONST(KindArray)
       instrs += I32_EQ
       fctx.ifThenElse(WasmRefType.any) {
@@ -198,7 +198,7 @@ object HelperFunctions {
         instrs += LOCAL_GET(typeDataParam)
         instrs += STRUCT_GET(
           WasmStructTypeName.typeData,
-          WasmFieldName.typeData.componentTypeIdx
+          WasmFieldIdx.typeData.componentTypeIdx
         )
         instrs += REF_AS_NOT_NULL
         instrs += LOCAL_SET(componentTypeDataLocal)
@@ -208,7 +208,7 @@ object HelperFunctions {
         fctx.switch(WasmRefType.any) { () =>
           // scrutinee
           instrs += LOCAL_GET(componentTypeDataLocal)
-          instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldName.typeData.kindIdx)
+          instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldIdx.typeData.kindIdx)
         }(
           List(KindBoolean) -> { () =>
             instrs += I32_CONST('Z'.toInt)
@@ -267,7 +267,7 @@ object HelperFunctions {
         instrs += LOCAL_GET(typeDataParam)
         instrs += STRUCT_GET(
           WasmStructTypeName.typeData,
-          WasmFieldName.typeData.nameDataIdx
+          WasmFieldIdx.typeData.nameDataIdx
         )
         instrs += REF_AS_NOT_NULL
         instrs += CALL(WasmFunctionName.createStringFromData)
@@ -275,7 +275,7 @@ object HelperFunctions {
 
       // typeData.name := <top of stack> ; leave it on the stack
       instrs += LOCAL_TEE(nameLocal)
-      instrs += STRUCT_SET(WasmStructTypeName.typeData, WasmFieldName.typeData.nameIdx)
+      instrs += STRUCT_SET(WasmStructTypeName.typeData, WasmFieldIdx.typeData.nameIdx)
       instrs += LOCAL_GET(nameLocal)
     }
 
@@ -330,7 +330,7 @@ object HelperFunctions {
     // "isPrimitive": (typeData.kind <= KindLastPrimitive)
     instrs ++= ctx.getConstantStringInstr("isPrimitive")
     instrs += LOCAL_GET(typeDataParam)
-    instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldName.typeData.kindIdx)
+    instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldIdx.typeData.kindIdx)
     instrs += I32_CONST(KindLastPrimitive)
     instrs += I32_LE_U
     instrs += CALL(WasmFunctionName.box(IRTypes.BooleanRef))
@@ -338,7 +338,7 @@ object HelperFunctions {
     // "isArrayClass": (typeData.kind == KindArray)
     instrs ++= ctx.getConstantStringInstr("isArrayClass")
     instrs += LOCAL_GET(typeDataParam)
-    instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldName.typeData.kindIdx)
+    instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldIdx.typeData.kindIdx)
     instrs += I32_CONST(KindArray)
     instrs += I32_EQ
     instrs += CALL(WasmFunctionName.box(IRTypes.BooleanRef))
@@ -346,7 +346,7 @@ object HelperFunctions {
     // "isInterface": (typeData.kind == KindInterface)
     instrs ++= ctx.getConstantStringInstr("isInterface")
     instrs += LOCAL_GET(typeDataParam)
-    instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldName.typeData.kindIdx)
+    instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldIdx.typeData.kindIdx)
     instrs += I32_CONST(KindInterface)
     instrs += I32_EQ
     instrs += CALL(WasmFunctionName.box(IRTypes.BooleanRef))
@@ -395,7 +395,7 @@ object HelperFunctions {
     // typeData.classOf := classInstance
     instrs += LOCAL_GET(typeDataParam)
     instrs += LOCAL_GET(classInstanceLocal)
-    instrs += STRUCT_SET(WasmStructTypeName.typeData, WasmFieldName.typeData.classOfIdx)
+    instrs += STRUCT_SET(WasmStructTypeName.typeData, WasmFieldIdx.typeData.classOfIdx)
 
     // <top-of-stack> := classInstance for the implicit return
     instrs += LOCAL_GET(classInstanceLocal)
@@ -430,7 +430,7 @@ object HelperFunctions {
     fctx.block(WasmRefType(WasmHeapType.ClassType)) { alreadyInitializedLabel =>
       // fast path
       instrs += LOCAL_GET(typeDataParam)
-      instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldName.typeData.classOfIdx)
+      instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldIdx.typeData.classOfIdx)
       instrs += BR_ON_NON_NULL(alreadyInitializedLabel)
       // slow path
       instrs += LOCAL_GET(typeDataParam)
@@ -478,7 +478,7 @@ object HelperFunctions {
         instrs += LOCAL_GET(typeDataParam)
         instrs += STRUCT_GET(
           WasmStructTypeName.typeData,
-          WasmFieldName.typeData.arrayOfIdx
+          WasmFieldIdx.typeData.arrayOfIdx
         )
         instrs += BR_ON_NON_NULL(arrayOfIsNonNullLabel)
 
@@ -512,7 +512,7 @@ object HelperFunctions {
         // <old typeData>.arrayOf := typeData
         instrs += STRUCT_SET(
           WasmStructTypeName.typeData,
-          WasmFieldName.typeData.arrayOfIdx
+          WasmFieldIdx.typeData.arrayOfIdx
         )
 
         // put arrayTypeData back on the stack
@@ -551,7 +551,7 @@ object HelperFunctions {
   private def genIsInstance()(implicit ctx: WasmContext): Unit = {
     import WasmImmediate._
     import WasmTypeName.WasmStructTypeName
-    import WasmFieldName.typeData._
+    import WasmFieldIdx.typeData._
 
     val typeDataType = WasmRefType(WasmStructType.typeData.name)
     val objectRefType = WasmRefType(WasmTypeName.WasmStructTypeName.forClass(IRNames.ObjectClass))
@@ -704,7 +704,7 @@ object HelperFunctions {
       }
       instrs += STRUCT_GET(
         WasmStructTypeName.forClass(IRNames.ObjectClass),
-        StructFieldIdx.vtable
+        WasmFieldIdx.vtable
       )
 
       // Call isAssignableFrom
@@ -755,7 +755,7 @@ object HelperFunctions {
   private def genIsAssignableFrom()(implicit ctx: WasmContext): Unit = {
     import WasmImmediate._
     import WasmTypeName._
-    import WasmFieldName.typeData._
+    import WasmFieldIdx.typeData._
 
     val typeDataType = WasmRefType(WasmStructType.typeData.name)
 
@@ -935,7 +935,7 @@ object HelperFunctions {
       instrs += LOCAL_GET(typeDataParam)
       instrs += STRUCT_GET(
         WasmStructTypeName.typeData,
-        WasmFieldName.typeData.componentTypeIdx
+        WasmFieldIdx.typeData.componentTypeIdx
       )
       instrs += BR_ON_NULL(nullResultLabel)
       // Get the corresponding classOf
@@ -1166,7 +1166,7 @@ object HelperFunctions {
           instrs += BR(gotTypeDataLabel)
         }
 
-        instrs += STRUCT_GET(WasmStructTypeName.forClass(IRNames.ObjectClass), StructFieldIdx(0))
+        instrs += STRUCT_GET(WasmStructTypeName.forClass(IRNames.ObjectClass), WasmFieldIdx.vtable)
       }
 
       instrs += CALL(WasmFunctionName.getClassOf)
@@ -1187,7 +1187,7 @@ object HelperFunctions {
   def genNewArrayObject()(implicit ctx: WasmContext): Unit = {
     import WasmImmediate._
     import WasmTypeName._
-    import WasmFieldName.typeData._
+    import WasmFieldIdx.typeData._
 
     val typeDataType = WasmRefType(WasmStructType.typeData.name)
     val i32ArrayType = WasmRefType(WasmTypeName.WasmArrayTypeName.i32Array)
@@ -1274,11 +1274,11 @@ object HelperFunctions {
       instrs += LOCAL_GET(arrayTypeDataParam)
       instrs += STRUCT_GET(
         WasmStructTypeName.typeData,
-        WasmFieldName.typeData.componentTypeIdx
+        WasmFieldIdx.typeData.componentTypeIdx
       )
       instrs += STRUCT_GET(
         WasmStructTypeName.typeData,
-        WasmFieldName.typeData.kindIdx
+        WasmFieldIdx.typeData.kindIdx
       )
     }(
       // For all the primitive types, by construction, this is the bottom dimension
@@ -1319,7 +1319,7 @@ object HelperFunctions {
         instrs += LOCAL_GET(arrayTypeDataParam)
         instrs += STRUCT_GET(
           WasmStructTypeName.typeData,
-          WasmFieldName.typeData.componentTypeIdx
+          WasmFieldIdx.typeData.componentTypeIdx
         )
         instrs += REF_CAST(WasmRefType(arrayTypeDataType.heapType))
         instrs += LOCAL_SET(arrayComponentTypeDataLocal)
@@ -1400,7 +1400,7 @@ object HelperFunctions {
       )
 
       // get itables and store
-      instrs += STRUCT_GET(Types.WasmHeapType.ObjectType.typ, StructFieldIdx.itables)
+      instrs += STRUCT_GET(Types.WasmHeapType.ObjectType.typ, WasmFieldIdx.itables)
       instrs += LOCAL_SET(itables)
 
       // Dummy return value from the block

--- a/wasm/src/main/scala/ir2wasm/TypeTransformer.scala
+++ b/wasm/src/main/scala/ir2wasm/TypeTransformer.scala
@@ -28,7 +28,13 @@ object TypeTransformer {
     WasmFunctionType(typeName, sig)
   }
 
-  /** This transformation should be used only for the result types of functions.
+  /** This transformation should be used only for the result types of functions or blocks.
+    *
+    * `nothing` translates to an empty result type list, because Wasm does not have a bottom type
+    * (at least not one that can expressed at the user level). A block or function call that returns
+    * `nothing` should typically be followed by an extra `unreachable` statement to recover a
+    * stack-polymorphic context.
+    *
     * @see
     *   https://webassembly.github.io/spec/core/syntax/types.html#result-types
     */
@@ -36,9 +42,16 @@ object TypeTransformer {
       t: IRTypes.Type
   )(implicit ctx: ReadOnlyWasmContext): List[Types.WasmType] =
     t match {
-      case IRTypes.NoType => Nil
-      case _              => List(transformType(t))
+      case IRTypes.NoType      => Nil
+      case IRTypes.NothingType => Nil
+      case _                   => List(transformType(t))
     }
+
+  /** Transforms a value type to a unique Wasm type.
+    *
+    * This method cannot be used for `void` and `nothing`, since they have no corresponding Wasm
+    * value type.
+    */
   def transformType(t: IRTypes.Type)(implicit ctx: ReadOnlyWasmContext): Types.WasmType =
     t match {
       case IRTypes.AnyType => Types.WasmAnyRef
@@ -85,9 +98,9 @@ object TypeTransformer {
       case IRTypes.LongType    => Types.WasmInt64
       case IRTypes.FloatType   => Types.WasmFloat32
       case IRTypes.DoubleType  => Types.WasmFloat64
-      // ???
-      case IRTypes.NothingType => Types.WasmRefNullrefType
       case IRTypes.NullType    => Types.WasmRefNullrefType
-      case IRTypes.NoType      => Types.WasmNoType
+
+      case IRTypes.NoType | IRTypes.NothingType =>
+        throw new IllegalArgumentException(s"${t.show()} does not have a corresponding Wasm type")
     }
 }

--- a/wasm/src/main/scala/ir2wasm/TypeTransformer.scala
+++ b/wasm/src/main/scala/ir2wasm/TypeTransformer.scala
@@ -54,13 +54,11 @@ object TypeTransformer {
     */
   def transformType(t: IRTypes.Type)(implicit ctx: ReadOnlyWasmContext): Types.WasmType =
     t match {
-      case IRTypes.AnyType => Types.WasmAnyRef
+      case IRTypes.AnyType => Types.WasmRefType.anyref
 
       case tpe: IRTypes.ArrayType =>
-        Types.WasmRefNullType(
-          Types.WasmHeapType.Type(
-            Names.WasmTypeName.WasmStructTypeName.forArrayClass(tpe.arrayTypeRef)
-          )
+        Types.WasmRefType.nullable(
+          Names.WasmTypeName.WasmStructTypeName.forArrayClass(tpe.arrayTypeRef)
         )
       case IRTypes.ClassType(className) => transformClassByName(className)
       case IRTypes.RecordType(fields)   => ???
@@ -76,12 +74,12 @@ object TypeTransformer {
       case _ =>
         val info = ctx.getClassInfo(className)
         if (info.isAncestorOfHijackedClass)
-          Types.WasmAnyRef
+          Types.WasmRefType.anyref
         else if (info.isInterface)
-          Types.WasmRefNullType(Types.WasmHeapType.ObjectType)
+          Types.WasmRefType.nullable(Types.WasmHeapType.ObjectType)
         else
-          Types.WasmRefNullType(
-            Types.WasmHeapType.Type(Names.WasmTypeName.WasmStructTypeName.forClass(className))
+          Types.WasmRefType.nullable(
+            Names.WasmTypeName.WasmStructTypeName.forClass(className)
           )
     }
   }
@@ -98,7 +96,7 @@ object TypeTransformer {
       case IRTypes.LongType    => Types.WasmInt64
       case IRTypes.FloatType   => Types.WasmFloat32
       case IRTypes.DoubleType  => Types.WasmFloat64
-      case IRTypes.NullType    => Types.WasmRefNullrefType
+      case IRTypes.NullType    => Types.WasmRefType.nullref
 
       case IRTypes.NoType | IRTypes.NothingType =>
         throw new IllegalArgumentException(s"${t.show()} does not have a corresponding Wasm type")

--- a/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
@@ -6,7 +6,6 @@ import wasm4s.WasmContext._
 import wasm4s.Names._
 import wasm4s.Types._
 import wasm4s.WasmInstr._
-import wasm4s.WasmImmediate._
 import TypeTransformer._
 
 import org.scalajs.ir.{Trees => IRTrees}
@@ -410,7 +409,7 @@ class WasmBuilder {
       // global.get $module_name
       GLOBAL_GET(globalInstanceName), // [rt]
       REF_IS_NULL, // [rt] -> [i32] (bool)
-      IF(WasmImmediate.BlockType.ValueType(None)),
+      IF(BlockType.ValueType()),
       CALL(WasmFunctionName.newDefault(clazz.name.name)),
       GLOBAL_SET(globalInstanceName),
       GLOBAL_GET(globalInstanceName),

--- a/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
@@ -13,7 +13,6 @@ import wasm4s._
 import wasm4s.Names._
 import wasm4s.Names.WasmTypeName._
 import wasm4s.WasmInstr._
-import wasm4s.WasmImmediate._
 import org.scalajs.ir.Types.ClassType
 import org.scalajs.ir.ClassKind
 import org.scalajs.ir.Position

--- a/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
@@ -220,7 +220,7 @@ private class WasmExpressionBuilder private (
             // Get the underlying array; implicit trap on null
             instrs += STRUCT_GET(
               WasmStructTypeName.forArrayClass(arrayTypeRef),
-              StructFieldIdx.uniqueRegularField
+              WasmFieldIdx.uniqueRegularField
             )
             genTree(sel.index, IRTypes.IntType)
             genTree(t.rhs, sel.tpe)
@@ -556,14 +556,14 @@ private class WasmExpressionBuilder private (
         // receiver type should be upcasted into `Object` if it's interface
         // by TypeTransformer#transformType
         WasmStructTypeName.forClass(IRNames.ObjectClass),
-        StructFieldIdx.itables
+        WasmFieldIdx.itables
       )
       instrs += I32_CONST(itableIdx)
       instrs += ARRAY_GET(WasmArrayType.itables.name)
       instrs += REF_CAST(Types.WasmRefType(WasmStructTypeName.forITable(receiverClassInfo.name)))
       instrs += STRUCT_GET(
         WasmStructTypeName.forITable(receiverClassInfo.name),
-        StructFieldIdx(methodIdx)
+        WasmFieldIdx(methodIdx)
       )
       instrs += CALL_REF(methodInfo.toWasmFunctionType()(ctx).name)
     }
@@ -592,11 +592,11 @@ private class WasmExpressionBuilder private (
       instrs += REF_CAST(Types.WasmRefType(WasmStructTypeName.forClass(receiverClassName)))
       instrs += STRUCT_GET(
         WasmStructTypeName.forClass(receiverClassName),
-        StructFieldIdx.vtable
+        WasmFieldIdx.vtable
       )
       instrs += STRUCT_GET(
         WasmStructTypeName.forVTable(receiverClassName),
-        StructFieldIdx(WasmStructType.typeDataFieldCount(ctx) + methodIdx)
+        WasmFieldIdx(WasmStructType.typeDataFieldCount(ctx) + methodIdx)
       )
       instrs += CALL_REF(info.toWasmFunctionType()(ctx).name)
     }
@@ -723,7 +723,7 @@ private class WasmExpressionBuilder private (
     fctx.block(Types.WasmRefType(Types.WasmHeapType.ClassType)) { nonNullLabel =>
       // fast path first
       instrs += loadTypeDataInstr
-      instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldName.typeData.classOfIdx)
+      instrs += STRUCT_GET(WasmStructTypeName.typeData, WasmFieldIdx.typeData.classOfIdx)
       instrs += BR_ON_NON_NULL(nonNullLabel)
       // slow path
       instrs += loadTypeDataInstr
@@ -1273,7 +1273,7 @@ private class WasmExpressionBuilder private (
 
                 // Load refArrayValue.vtable
                 instrs += LOCAL_GET(refArrayValueLocal)
-                instrs += STRUCT_GET(refArrayStructTypeName, StructFieldIdx.vtable)
+                instrs += STRUCT_GET(refArrayStructTypeName, WasmFieldIdx.vtable)
 
                 // Call isAssignableFrom and return its result
                 instrs += CALL(WasmFunctionName.isAssignableFrom)
@@ -1378,12 +1378,12 @@ private class WasmExpressionBuilder private (
             // TODO Handle null
             val structTypeName = WasmStructTypeName.forClass(SpecialNames.CharBoxClass)
             instrs += REF_CAST(Types.WasmRefType(structTypeName))
-            instrs += STRUCT_GET(structTypeName, StructFieldIdx.uniqueRegularField)
+            instrs += STRUCT_GET(structTypeName, WasmFieldIdx.uniqueRegularField)
           case IRTypes.LongType =>
             // TODO Handle null
             val structTypeName = WasmStructTypeName.forClass(SpecialNames.LongBoxClass)
             instrs += REF_CAST(Types.WasmRefType(structTypeName))
-            instrs += STRUCT_GET(structTypeName, StructFieldIdx.uniqueRegularField)
+            instrs += STRUCT_GET(structTypeName, WasmFieldIdx.uniqueRegularField)
           case IRTypes.NothingType | IRTypes.NullType | IRTypes.NoType =>
             throw new IllegalArgumentException(s"Illegal type in genUnbox: $targetTpe")
           case _ =>
@@ -1417,7 +1417,7 @@ private class WasmExpressionBuilder private (
       val typeDataLocal = fctx.addSyntheticLocal(typeDataType)
 
       genTreeAuto(tree.expr)
-      instrs += STRUCT_GET(objectTypeIdx, StructFieldIdx.vtable) // implicit trap on null
+      instrs += STRUCT_GET(objectTypeIdx, WasmFieldIdx.vtable) // implicit trap on null
       instrs += LOCAL_SET(typeDataLocal)
       genClassOfFromTypeData(LOCAL_GET(typeDataLocal))
     } else {
@@ -1741,7 +1741,7 @@ private class WasmExpressionBuilder private (
     instrs += LOCAL_GET(primLocal)
     instrs += STRUCT_SET(
       WasmStructTypeName.forClass(boxClassName),
-      StructFieldIdx.uniqueRegularField
+      WasmFieldIdx.uniqueRegularField
     )
     instrs += LOCAL_GET(instanceLocal)
 
@@ -2045,7 +2045,7 @@ private class WasmExpressionBuilder private (
         // Get the underlying array; implicit trap on null
         instrs += STRUCT_GET(
           WasmStructTypeName.forArrayClass(arrayTypeRef),
-          StructFieldIdx.uniqueRegularField
+          WasmFieldIdx.uniqueRegularField
         )
         // Get the length
         instrs += ARRAY_LEN
@@ -2127,7 +2127,7 @@ private class WasmExpressionBuilder private (
         // Get the underlying array; implicit trap on null
         instrs += STRUCT_GET(
           WasmStructTypeName.forArrayClass(arrayTypeRef),
-          StructFieldIdx.uniqueRegularField
+          WasmFieldIdx.uniqueRegularField
         )
 
         // Load the index
@@ -2266,11 +2266,11 @@ private class WasmExpressionBuilder private (
     instrs += LOCAL_GET(expr)
     instrs += STRUCT_GET(
       WasmStructTypeName.forClass(IRNames.ObjectClass),
-      StructFieldIdx.vtable
+      WasmFieldIdx.vtable
     )
     instrs += STRUCT_GET(
       WasmTypeName.WasmStructTypeName.typeData,
-      WasmFieldName.typeData.cloneFunctionIdx
+      WasmFieldIdx.typeData.cloneFunctionIdx
     )
     // cloneFunction: (ref j.l.Object) -> ref j.l.Object
     instrs += CALL_REF(ctx.cloneFunctionTypeName)

--- a/wasm/src/main/scala/wasm4s/Defaults.scala
+++ b/wasm/src/main/scala/wasm4s/Defaults.scala
@@ -8,11 +8,11 @@ import wasm.wasm4s.WasmInstr._
 object Defaults {
   private def nonDefaultable(t: WasmStorageType) = throw new Error(s"Non defaultable type: $t")
   def defaultValue(t: WasmStorageType): WasmInstr = t match {
-    case WasmInt32                   => I32_CONST(I32(0))
-    case WasmInt64                   => I64_CONST(I64(0))
-    case WasmFloat32                 => F32_CONST(F32(0))
-    case WasmFloat64                 => F64_CONST(F64(0))
-    case WasmRefType(true, heapType) => REF_NULL(HeapType(heapType))
+    case WasmInt32                   => I32_CONST(0)
+    case WasmInt64                   => I64_CONST(0)
+    case WasmFloat32                 => F32_CONST(0)
+    case WasmFloat64                 => F64_CONST(0)
+    case WasmRefType(true, heapType) => REF_NULL(heapType)
     case WasmRefType(false, _)       => nonDefaultable(t)
     case WasmInt8                    => nonDefaultable(t)
     case WasmInt16                   => nonDefaultable(t)

--- a/wasm/src/main/scala/wasm4s/Defaults.scala
+++ b/wasm/src/main/scala/wasm4s/Defaults.scala
@@ -8,21 +8,13 @@ import wasm.wasm4s.WasmInstr._
 object Defaults {
   private def nonDefaultable(t: WasmStorageType) = throw new Error(s"Non defaultable type: $t")
   def defaultValue(t: WasmStorageType): WasmInstr = t match {
-    case WasmUnreachableType       => UNREACHABLE
-    case WasmInt32                 => I32_CONST(I32(0))
-    case WasmAnyRef                => REF_NULL(HeapType(WasmHeapType.Simple.Any))
-    case WasmExternRef             => REF_NULL(HeapType(WasmHeapType.Simple.NoExtern))
-    case WasmExnRef                => REF_NULL(HeapType(WasmHeapType.Simple.NoExn))
-    case WasmRefType(_)            => nonDefaultable(t)
-    case WasmFloat32               => F32_CONST(F32(0))
-    case WasmFuncRef               => REF_NULL(HeapType(WasmHeapType.Simple.Func))
-    case WasmRefNullExternrefType  => REF_NULL(HeapType(WasmHeapType.Simple.NoExtern))
-    case WasmEqRef                 => REF_NULL(HeapType(WasmHeapType.Simple.Eq))
-    case WasmRefNullrefType        => REF_NULL(HeapType(WasmHeapType.Simple.None))
-    case WasmRefNullType(heapType) => REF_NULL(HeapType(heapType))
-    case WasmInt64                 => I64_CONST(I64(0))
-    case WasmFloat64               => F64_CONST(F64(0))
-    case WasmInt16                 => nonDefaultable(t)
-    case WasmInt8                  => nonDefaultable(t)
+    case WasmInt32                   => I32_CONST(I32(0))
+    case WasmInt64                   => I64_CONST(I64(0))
+    case WasmFloat32                 => F32_CONST(F32(0))
+    case WasmFloat64                 => F64_CONST(F64(0))
+    case WasmRefType(true, heapType) => REF_NULL(HeapType(heapType))
+    case WasmRefType(false, _)       => nonDefaultable(t)
+    case WasmInt8                    => nonDefaultable(t)
+    case WasmInt16                   => nonDefaultable(t)
   }
 }

--- a/wasm/src/main/scala/wasm4s/Defaults.scala
+++ b/wasm/src/main/scala/wasm4s/Defaults.scala
@@ -24,6 +24,5 @@ object Defaults {
     case WasmFloat64               => F64_CONST(F64(0))
     case WasmInt16                 => nonDefaultable(t)
     case WasmInt8                  => nonDefaultable(t)
-    case WasmNoType                => nonDefaultable(t)
   }
 }

--- a/wasm/src/main/scala/wasm4s/Defaults.scala
+++ b/wasm/src/main/scala/wasm4s/Defaults.scala
@@ -1,7 +1,6 @@
 package wasm4s
 
 import wasm.wasm4s.Types._
-import wasm.wasm4s.WasmImmediate._
 import wasm.wasm4s.WasmInstr
 import wasm.wasm4s.WasmInstr._
 

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -5,199 +5,267 @@ import Types._
 import Names._
 import Names.WasmTypeName._
 
-abstract sealed class WasmInstr(
-    val mnemonic: String,
-    val opcode: Int,
-    val immediates: List[WasmImmediate] = Nil
-)
+sealed abstract class WasmInstr(val mnemonic: String, val opcode: Int)
+
 object WasmInstr {
   import WasmImmediate._
 
+  // Semantic categories of instructions
+
+  /** A stack-polymorphic instruction. */
   sealed trait StackPolymorphicInstr extends WasmInstr
 
-  case object I32_EQZ extends WasmInstr("i32.eqz", 0x45)
-  case object I64_EQZ extends WasmInstr("i64.eqz", 0x50)
-  case object I32_CLZ extends WasmInstr("i32.clz", 0x67)
-  case object I32_CTZ extends WasmInstr("i32.ctz", 0x68)
-  case object I32_POPCNT extends WasmInstr("i32.popcnt", 0x69)
-  case object I64_CLZ extends WasmInstr("i64.clz", 0x79)
-  case object I64_CTZ extends WasmInstr("i64.ctz", 0x7A)
-  case object I64_POPCNT extends WasmInstr("i64.popcnt", 0x7B)
-  case object F32_ABS extends WasmInstr("f32.abs", 0x8B)
-  case object F32_NEG extends WasmInstr("f32.neg", 0x8C)
-  case object F32_CEIL extends WasmInstr("f32.ceil", 0x8D)
-  case object F32_FLOOR extends WasmInstr("f32.floor", 0x8E)
-  case object F32_TRUNC extends WasmInstr("f32.trunc", 0x8F)
-  case object F32_NEAREST extends WasmInstr("f32.nearest", 0x90)
-  case object F32_SQRT extends WasmInstr("f32.sqrt", 0x91)
-  case object F64_ABS extends WasmInstr("f64.abs", 0x99)
-  case object F64_NEG extends WasmInstr("f64.neg", 0x9A)
-  case object F64_CEIL extends WasmInstr("f64.ceil", 0x9B)
-  case object F64_FLOOR extends WasmInstr("f64.floor", 0x9C)
-  case object F64_TRUNC extends WasmInstr("f64.trunc", 0x9D)
-  case object F64_NEAREST extends WasmInstr("f64.nearest", 0x9E)
-  case object F64_SQRT extends WasmInstr("f64.sqrt", 0x9F)
-  case object I32_WRAP_I64 extends WasmInstr("i32.wrap_i64", 0xA7)
-  case object I32_TRUNC_F32_S extends WasmInstr("i32.trunc_f32_s", 0xA8)
-  case object I32_TRUNC_F32_U extends WasmInstr("i32.trunc_f32_u", 0xA9)
-  case object I32_TRUNC_F64_S extends WasmInstr("i32.trunc_f64_s", 0xAA)
-  case object I32_TRUNC_F64_U extends WasmInstr("i32.trunc_f64_u", 0xAB)
-  case object I64_EXTEND_I32_S extends WasmInstr("i64.extend_i32_s", 0xAC)
-  case object I64_EXTEND_I32_U extends WasmInstr("i64.extend_i32_u", 0xAD)
-  case object I64_TRUNC_F32_S extends WasmInstr("i64.trunc_f32_s", 0xAE)
-  case object I64_TRUNC_F32_U extends WasmInstr("i64.trunc_f32_u", 0xAF)
-  case object I64_TRUNC_F64_S extends WasmInstr("i64.trunc_f64_s", 0xB0)
-  case object I64_TRUNC_F64_U extends WasmInstr("i64.trunc_f64_u", 0xB1)
-  case object F32_CONVERT_I32_S extends WasmInstr("f32.convert_i32_s", 0xB2)
-  case object F32_CONVERT_I32_U extends WasmInstr("f32.convert_i32_u", 0xB3)
-  case object F32_CONVERT_I64_S extends WasmInstr("f32.convert_i64_s", 0xB4)
-  case object F32_CONVERT_I64_U extends WasmInstr("f32.convert_i64_u", 0xB5)
-  case object F32_DEMOTE_F64 extends WasmInstr("f32.demote_f64", 0xB6)
-  case object F64_CONVERT_I32_S extends WasmInstr("f64.convert_i32_s", 0xB7)
-  case object F64_CONVERT_I32_U extends WasmInstr("f64.convert_i32_u", 0xB8)
-  case object F64_CONVERT_I64_S extends WasmInstr("f64.convert_i64_s", 0xB9)
-  case object F64_CONVERT_I64_U extends WasmInstr("f64.convert_i64_u", 0xBA)
-  case object F64_PROMOTE_F32 extends WasmInstr("f64.promote_f32", 0xBB)
-  case object I32_REINTERPRET_F32 extends WasmInstr("i32.reinterpret_f32", 0xBC)
-  case object I64_REINTERPRET_F64 extends WasmInstr("i64.reinterpret_f64", 0xBD)
-  case object F32_REINTERPRET_I32 extends WasmInstr("f32.reinterpret_i32", 0xBE)
-  case object F64_REINTERPRET_I64 extends WasmInstr("f64.reinterpret_i64", 0xBF)
-  case object I32_EXTEND8_S extends WasmInstr("i32.extend8_s", 0xC0)
-  case object I32_EXTEND16_S extends WasmInstr("i32.extend16_s", 0xC1)
-  case object I64_EXTEND8_S extends WasmInstr("i64.extend8_s", 0xC2)
-  case object I64_EXTEND16_S extends WasmInstr("i64.extend16_s", 0xC3)
-  case object I64_EXTEND32_S extends WasmInstr("i64.extend32_s", 0xC4)
-  case object I32_TRUNC_SAT_F64_S extends WasmInstr("i32.trunc_sat_f64_s", 0xFC02)
-  case object I64_TRUNC_SAT_F64_S extends WasmInstr("i64.trunc_sat_f64_s", 0xFC06)
-
-  // Binary operations
-  case object I32_EQ extends WasmInstr("i32.eq", 0x46)
-  case object I32_NE extends WasmInstr("i32.ne", 0x47)
-  case object I32_LT_S extends WasmInstr("i32.lt_s", 0x48)
-  case object I32_LT_U extends WasmInstr("i32.lt_u", 0x49)
-  case object I32_GT_S extends WasmInstr("i32.gt_s", 0x4A)
-  case object I32_GT_U extends WasmInstr("i32.gt_u", 0x4B)
-  case object I32_LE_S extends WasmInstr("i32.le_s", 0x4C)
-  case object I32_LE_U extends WasmInstr("i32.le_u", 0x4D)
-  case object I32_GE_S extends WasmInstr("i32.ge_s", 0x4E)
-  case object I32_GE_U extends WasmInstr("i32.ge_u", 0x4F)
-  case object I64_EQ extends WasmInstr("i64.eq", 0x51)
-  case object I64_NE extends WasmInstr("i64.ne", 0x52)
-  case object I64_LT_S extends WasmInstr("i64.lt_s", 0x53)
-  case object I64_LT_U extends WasmInstr("i64.lt_u", 0x54)
-  case object I64_GT_S extends WasmInstr("i64.gt_s", 0x55)
-  case object I64_GT_U extends WasmInstr("i64.gt_u", 0x56)
-  case object I64_LE_S extends WasmInstr("i64.le_s", 0x57)
-  case object I64_LE_U extends WasmInstr("i64.le_u", 0x58)
-  case object I64_GE_S extends WasmInstr("i64.ge_s", 0x59)
-  case object I64_GE_U extends WasmInstr("i64.ge_u", 0x5A)
-  case object F32_EQ extends WasmInstr("f32.eq", 0x5B)
-  case object F32_NE extends WasmInstr("f32.ne", 0x5C)
-  case object F32_LT extends WasmInstr("f32.lt", 0x5D)
-  case object F32_GT extends WasmInstr("f32.gt", 0x5E)
-  case object F32_LE extends WasmInstr("f32.le", 0x5F)
-  case object F32_GE extends WasmInstr("f32.ge", 0x60)
-  case object F64_EQ extends WasmInstr("f64.eq", 0x61)
-  case object F64_NE extends WasmInstr("f64.ne", 0x62)
-  case object F64_LT extends WasmInstr("f64.lt", 0x63)
-  case object F64_GT extends WasmInstr("f64.gt", 0x64)
-  case object F64_LE extends WasmInstr("f64.le", 0x65)
-  case object F64_GE extends WasmInstr("f64.ge", 0x66)
-  case object I32_ADD extends WasmInstr("i32.add", 0x6A)
-  case object I32_SUB extends WasmInstr("i32.sub", 0x6B)
-  case object I32_MUL extends WasmInstr("i32.mul", 0x6C)
-  case object I32_DIV_S extends WasmInstr("i32.div_s", 0x6D)
-  case object I32_DIV_U extends WasmInstr("i32.div_u", 0x6E)
-  case object I32_REM_S extends WasmInstr("i32.rem_s", 0x6F)
-  case object I32_REM_U extends WasmInstr("i32.rem_u", 0x70)
-  case object I32_AND extends WasmInstr("i32.and", 0x71)
-  case object I32_OR extends WasmInstr("i32.or", 0x72)
-  case object I32_XOR extends WasmInstr("i32.xor", 0x73)
-  case object I32_SHL extends WasmInstr("i32.shl", 0x74)
-  case object I32_SHR_S extends WasmInstr("i32.shr_s", 0x75)
-  case object I32_SHR_U extends WasmInstr("i32.shr_u", 0x76)
-  case object I32_ROTL extends WasmInstr("i32.rotl", 0x77)
-  case object I32_ROTR extends WasmInstr("i32.rotr", 0x78)
-  case object I64_ADD extends WasmInstr("i64.add", 0x7C)
-  case object I64_SUB extends WasmInstr("i64.sub", 0x7D)
-  case object I64_MUL extends WasmInstr("i64.mul", 0x7E)
-  case object I64_DIV_S extends WasmInstr("i64.div_s", 0x7F)
-  case object I64_DIV_U extends WasmInstr("i64.div_u", 0x80)
-  case object I64_REM_S extends WasmInstr("i64.rem_s", 0x81)
-  case object I64_REM_U extends WasmInstr("i64.rem_u", 0x82)
-  case object I64_AND extends WasmInstr("i64.and", 0x83)
-  case object I64_OR extends WasmInstr("i64.or", 0x84)
-  case object I64_XOR extends WasmInstr("i64.xor", 0x85)
-  case object I64_SHL extends WasmInstr("i64.shl", 0x86)
-  case object I64_SHR_S extends WasmInstr("i64.shr_s", 0x87)
-  case object I64_SHR_U extends WasmInstr("i64.shr_u", 0x88)
-  case object I64_ROTL extends WasmInstr("i64.rotl", 0x89)
-  case object I64_ROTR extends WasmInstr("i64.rotr", 0x8A)
-  case object F32_ADD extends WasmInstr("f32.add", 0x92)
-  case object F32_SUB extends WasmInstr("f32.sub", 0x93)
-  case object F32_MUL extends WasmInstr("f32.mul", 0x94)
-  case object F32_DIV extends WasmInstr("f32.div", 0x95)
-  case object F32_MIN extends WasmInstr("f32.min", 0x96)
-  case object F32_MAX extends WasmInstr("f32.max", 0x97)
-  case object F32_COPYSIGN extends WasmInstr("f32.copysign", 0x98)
-  case object F64_ADD extends WasmInstr("f64.add", 0xA0)
-  case object F64_SUB extends WasmInstr("f64.sub", 0xA1)
-  case object F64_MUL extends WasmInstr("f64.mul", 0xA2)
-  case object F64_DIV extends WasmInstr("f64.div", 0xA3)
-  case object F64_MIN extends WasmInstr("f64.min", 0xA4)
-  case object F64_MAX extends WasmInstr("f64.max", 0xA5)
-
-  case class I32_CONST(v: I32) extends WasmInstr("i32.const", 0x41, List(v))
-  object I32_CONST { def apply(v: Int): I32_CONST = I32_CONST(I32(v)) }
-  case class I64_CONST(v: I64) extends WasmInstr("i64.const", 0x42, List(v))
-  object I64_CONST { def apply(v: Long): I64_CONST = I64_CONST(I64(v)) }
-  case class F32_CONST(v: F32) extends WasmInstr("f32.const", 0x43, List(v))
-  case class F64_CONST(v: F64) extends WasmInstr("f64.const", 0x44, List(v))
-
-  // Control instructions
-  // https://webassembly.github.io/spec/core/syntax/instructions.html#control-instructions
-  sealed abstract class StructuredLabeledInstr(
-      mnemonic: String,
-      opcode: Int,
-      immediates: List[WasmImmediate]
-  ) extends WasmInstr(mnemonic, opcode, immediates) {
+  /** An instruction that opens a structured control block. */
+  sealed trait StructuredLabeledInstr extends WasmInstr {
     val label: Option[LabelIdx]
   }
 
-  case object UNREACHABLE extends WasmInstr("unreachable", 0x00) with StackPolymorphicInstr
-  case object NOP extends WasmInstr("nop", 0x01)
+  // Convenience subclasses of instructions for writing text/binary
+
+  /** An instruction without any immediate argument. */
+  sealed abstract class WasmSimpleInstr(mnemonic: String, opcode: Int)
+      extends WasmInstr(mnemonic, opcode)
+
+  /** A structured labeled instruction with a single `BlockType` argument. */
+  sealed abstract class WasmBlockTypeLabeledInstr(
+      mnemonic: String,
+      opcode: Int,
+      val blockTypeArgument: BlockType
+  ) extends WasmInstr(mnemonic, opcode)
+      with StructuredLabeledInstr
+
+  /** An instruction with a single `LabelIdx` argument. */
+  sealed abstract class WasmLabelInstr(mnemonic: String, opcode: Int, val labelArgument: LabelIdx)
+      extends WasmInstr(mnemonic, opcode)
+
+  /** An instruction with a single `FuncIdx` argument. */
+  sealed abstract class WasmFuncInstr(mnemonic: String, opcode: Int, val funcArgument: FuncIdx)
+      extends WasmInstr(mnemonic, opcode)
+
+  /** An instruction with a single `TypeIdx` argument. */
+  sealed abstract class WasmTypeInstr(mnemonic: String, opcode: Int, val typeArgument: TypeIdx)
+      extends WasmInstr(mnemonic, opcode)
+
+  /** An instruction with a single `TagIdx` argument. */
+  sealed abstract class WasmTagInstr(mnemonic: String, opcode: Int, val tagArgument: TagIdx)
+      extends WasmInstr(mnemonic, opcode)
+
+  /** An instruction with a single `LocalIdx` argument. */
+  sealed abstract class WasmLocalInstr(mnemonic: String, opcode: Int, val localArgument: LocalIdx)
+      extends WasmInstr(mnemonic, opcode)
+
+  /** An instruction with a single `GlobalIdx` argument. */
+  sealed abstract class WasmGlobalInstr(
+      mnemonic: String,
+      opcode: Int,
+      val globalArgument: GlobalIdx
+  ) extends WasmInstr(mnemonic, opcode)
+
+  /** An instruction with a single `HeapType` argument. */
+  sealed abstract class WasmHeapTypeInstr(
+      mnemonic: String,
+      opcode: Int,
+      val heapTypeArgument: HeapType
+  ) extends WasmInstr(mnemonic, opcode)
+
+  /** An instruction with a single `WasmRefType` argument
+    *
+    * In the binary format, it has split opcodes for the nullable and non-nullable variants.
+    */
+  sealed abstract class WasmRefTypeInstr(
+      mnemonic: String,
+      nonNullOpcode: Int,
+      nullOpcode: Int,
+      val refTypeArgument: WasmRefType
+  ) extends WasmInstr(mnemonic, if (refTypeArgument.nullable) nullOpcode else nonNullOpcode)
+
+  /** An instruction with a pair of `TypeIdx`, `StructFieldIdx` arguments. */
+  sealed abstract class WasmStructFieldInstr(
+      mnemonic: String,
+      opcode: Int,
+      val structTypeIdx: TypeIdx,
+      val fieldIdx: StructFieldIdx
+  ) extends WasmInstr(mnemonic, opcode)
+
+  // The actual instruction list
+
+  // Unary operations
+  case object I32_EQZ extends WasmSimpleInstr("i32.eqz", 0x45)
+  case object I64_EQZ extends WasmSimpleInstr("i64.eqz", 0x50)
+  case object I32_CLZ extends WasmSimpleInstr("i32.clz", 0x67)
+  case object I32_CTZ extends WasmSimpleInstr("i32.ctz", 0x68)
+  case object I32_POPCNT extends WasmSimpleInstr("i32.popcnt", 0x69)
+  case object I64_CLZ extends WasmSimpleInstr("i64.clz", 0x79)
+  case object I64_CTZ extends WasmSimpleInstr("i64.ctz", 0x7A)
+  case object I64_POPCNT extends WasmSimpleInstr("i64.popcnt", 0x7B)
+  case object F32_ABS extends WasmSimpleInstr("f32.abs", 0x8B)
+  case object F32_NEG extends WasmSimpleInstr("f32.neg", 0x8C)
+  case object F32_CEIL extends WasmSimpleInstr("f32.ceil", 0x8D)
+  case object F32_FLOOR extends WasmSimpleInstr("f32.floor", 0x8E)
+  case object F32_TRUNC extends WasmSimpleInstr("f32.trunc", 0x8F)
+  case object F32_NEAREST extends WasmSimpleInstr("f32.nearest", 0x90)
+  case object F32_SQRT extends WasmSimpleInstr("f32.sqrt", 0x91)
+  case object F64_ABS extends WasmSimpleInstr("f64.abs", 0x99)
+  case object F64_NEG extends WasmSimpleInstr("f64.neg", 0x9A)
+  case object F64_CEIL extends WasmSimpleInstr("f64.ceil", 0x9B)
+  case object F64_FLOOR extends WasmSimpleInstr("f64.floor", 0x9C)
+  case object F64_TRUNC extends WasmSimpleInstr("f64.trunc", 0x9D)
+  case object F64_NEAREST extends WasmSimpleInstr("f64.nearest", 0x9E)
+  case object F64_SQRT extends WasmSimpleInstr("f64.sqrt", 0x9F)
+  case object I32_WRAP_I64 extends WasmSimpleInstr("i32.wrap_i64", 0xA7)
+  case object I32_TRUNC_F32_S extends WasmSimpleInstr("i32.trunc_f32_s", 0xA8)
+  case object I32_TRUNC_F32_U extends WasmSimpleInstr("i32.trunc_f32_u", 0xA9)
+  case object I32_TRUNC_F64_S extends WasmSimpleInstr("i32.trunc_f64_s", 0xAA)
+  case object I32_TRUNC_F64_U extends WasmSimpleInstr("i32.trunc_f64_u", 0xAB)
+  case object I64_EXTEND_I32_S extends WasmSimpleInstr("i64.extend_i32_s", 0xAC)
+  case object I64_EXTEND_I32_U extends WasmSimpleInstr("i64.extend_i32_u", 0xAD)
+  case object I64_TRUNC_F32_S extends WasmSimpleInstr("i64.trunc_f32_s", 0xAE)
+  case object I64_TRUNC_F32_U extends WasmSimpleInstr("i64.trunc_f32_u", 0xAF)
+  case object I64_TRUNC_F64_S extends WasmSimpleInstr("i64.trunc_f64_s", 0xB0)
+  case object I64_TRUNC_F64_U extends WasmSimpleInstr("i64.trunc_f64_u", 0xB1)
+  case object F32_CONVERT_I32_S extends WasmSimpleInstr("f32.convert_i32_s", 0xB2)
+  case object F32_CONVERT_I32_U extends WasmSimpleInstr("f32.convert_i32_u", 0xB3)
+  case object F32_CONVERT_I64_S extends WasmSimpleInstr("f32.convert_i64_s", 0xB4)
+  case object F32_CONVERT_I64_U extends WasmSimpleInstr("f32.convert_i64_u", 0xB5)
+  case object F32_DEMOTE_F64 extends WasmSimpleInstr("f32.demote_f64", 0xB6)
+  case object F64_CONVERT_I32_S extends WasmSimpleInstr("f64.convert_i32_s", 0xB7)
+  case object F64_CONVERT_I32_U extends WasmSimpleInstr("f64.convert_i32_u", 0xB8)
+  case object F64_CONVERT_I64_S extends WasmSimpleInstr("f64.convert_i64_s", 0xB9)
+  case object F64_CONVERT_I64_U extends WasmSimpleInstr("f64.convert_i64_u", 0xBA)
+  case object F64_PROMOTE_F32 extends WasmSimpleInstr("f64.promote_f32", 0xBB)
+  case object I32_REINTERPRET_F32 extends WasmSimpleInstr("i32.reinterpret_f32", 0xBC)
+  case object I64_REINTERPRET_F64 extends WasmSimpleInstr("i64.reinterpret_f64", 0xBD)
+  case object F32_REINTERPRET_I32 extends WasmSimpleInstr("f32.reinterpret_i32", 0xBE)
+  case object F64_REINTERPRET_I64 extends WasmSimpleInstr("f64.reinterpret_i64", 0xBF)
+  case object I32_EXTEND8_S extends WasmSimpleInstr("i32.extend8_s", 0xC0)
+  case object I32_EXTEND16_S extends WasmSimpleInstr("i32.extend16_s", 0xC1)
+  case object I64_EXTEND8_S extends WasmSimpleInstr("i64.extend8_s", 0xC2)
+  case object I64_EXTEND16_S extends WasmSimpleInstr("i64.extend16_s", 0xC3)
+  case object I64_EXTEND32_S extends WasmSimpleInstr("i64.extend32_s", 0xC4)
+  case object I32_TRUNC_SAT_F64_S extends WasmSimpleInstr("i32.trunc_sat_f64_s", 0xFC02)
+  case object I64_TRUNC_SAT_F64_S extends WasmSimpleInstr("i64.trunc_sat_f64_s", 0xFC06)
+
+  // Binary operations
+  case object I32_EQ extends WasmSimpleInstr("i32.eq", 0x46)
+  case object I32_NE extends WasmSimpleInstr("i32.ne", 0x47)
+  case object I32_LT_S extends WasmSimpleInstr("i32.lt_s", 0x48)
+  case object I32_LT_U extends WasmSimpleInstr("i32.lt_u", 0x49)
+  case object I32_GT_S extends WasmSimpleInstr("i32.gt_s", 0x4A)
+  case object I32_GT_U extends WasmSimpleInstr("i32.gt_u", 0x4B)
+  case object I32_LE_S extends WasmSimpleInstr("i32.le_s", 0x4C)
+  case object I32_LE_U extends WasmSimpleInstr("i32.le_u", 0x4D)
+  case object I32_GE_S extends WasmSimpleInstr("i32.ge_s", 0x4E)
+  case object I32_GE_U extends WasmSimpleInstr("i32.ge_u", 0x4F)
+  case object I64_EQ extends WasmSimpleInstr("i64.eq", 0x51)
+  case object I64_NE extends WasmSimpleInstr("i64.ne", 0x52)
+  case object I64_LT_S extends WasmSimpleInstr("i64.lt_s", 0x53)
+  case object I64_LT_U extends WasmSimpleInstr("i64.lt_u", 0x54)
+  case object I64_GT_S extends WasmSimpleInstr("i64.gt_s", 0x55)
+  case object I64_GT_U extends WasmSimpleInstr("i64.gt_u", 0x56)
+  case object I64_LE_S extends WasmSimpleInstr("i64.le_s", 0x57)
+  case object I64_LE_U extends WasmSimpleInstr("i64.le_u", 0x58)
+  case object I64_GE_S extends WasmSimpleInstr("i64.ge_s", 0x59)
+  case object I64_GE_U extends WasmSimpleInstr("i64.ge_u", 0x5A)
+  case object F32_EQ extends WasmSimpleInstr("f32.eq", 0x5B)
+  case object F32_NE extends WasmSimpleInstr("f32.ne", 0x5C)
+  case object F32_LT extends WasmSimpleInstr("f32.lt", 0x5D)
+  case object F32_GT extends WasmSimpleInstr("f32.gt", 0x5E)
+  case object F32_LE extends WasmSimpleInstr("f32.le", 0x5F)
+  case object F32_GE extends WasmSimpleInstr("f32.ge", 0x60)
+  case object F64_EQ extends WasmSimpleInstr("f64.eq", 0x61)
+  case object F64_NE extends WasmSimpleInstr("f64.ne", 0x62)
+  case object F64_LT extends WasmSimpleInstr("f64.lt", 0x63)
+  case object F64_GT extends WasmSimpleInstr("f64.gt", 0x64)
+  case object F64_LE extends WasmSimpleInstr("f64.le", 0x65)
+  case object F64_GE extends WasmSimpleInstr("f64.ge", 0x66)
+  case object I32_ADD extends WasmSimpleInstr("i32.add", 0x6A)
+  case object I32_SUB extends WasmSimpleInstr("i32.sub", 0x6B)
+  case object I32_MUL extends WasmSimpleInstr("i32.mul", 0x6C)
+  case object I32_DIV_S extends WasmSimpleInstr("i32.div_s", 0x6D)
+  case object I32_DIV_U extends WasmSimpleInstr("i32.div_u", 0x6E)
+  case object I32_REM_S extends WasmSimpleInstr("i32.rem_s", 0x6F)
+  case object I32_REM_U extends WasmSimpleInstr("i32.rem_u", 0x70)
+  case object I32_AND extends WasmSimpleInstr("i32.and", 0x71)
+  case object I32_OR extends WasmSimpleInstr("i32.or", 0x72)
+  case object I32_XOR extends WasmSimpleInstr("i32.xor", 0x73)
+  case object I32_SHL extends WasmSimpleInstr("i32.shl", 0x74)
+  case object I32_SHR_S extends WasmSimpleInstr("i32.shr_s", 0x75)
+  case object I32_SHR_U extends WasmSimpleInstr("i32.shr_u", 0x76)
+  case object I32_ROTL extends WasmSimpleInstr("i32.rotl", 0x77)
+  case object I32_ROTR extends WasmSimpleInstr("i32.rotr", 0x78)
+  case object I64_ADD extends WasmSimpleInstr("i64.add", 0x7C)
+  case object I64_SUB extends WasmSimpleInstr("i64.sub", 0x7D)
+  case object I64_MUL extends WasmSimpleInstr("i64.mul", 0x7E)
+  case object I64_DIV_S extends WasmSimpleInstr("i64.div_s", 0x7F)
+  case object I64_DIV_U extends WasmSimpleInstr("i64.div_u", 0x80)
+  case object I64_REM_S extends WasmSimpleInstr("i64.rem_s", 0x81)
+  case object I64_REM_U extends WasmSimpleInstr("i64.rem_u", 0x82)
+  case object I64_AND extends WasmSimpleInstr("i64.and", 0x83)
+  case object I64_OR extends WasmSimpleInstr("i64.or", 0x84)
+  case object I64_XOR extends WasmSimpleInstr("i64.xor", 0x85)
+  case object I64_SHL extends WasmSimpleInstr("i64.shl", 0x86)
+  case object I64_SHR_S extends WasmSimpleInstr("i64.shr_s", 0x87)
+  case object I64_SHR_U extends WasmSimpleInstr("i64.shr_u", 0x88)
+  case object I64_ROTL extends WasmSimpleInstr("i64.rotl", 0x89)
+  case object I64_ROTR extends WasmSimpleInstr("i64.rotr", 0x8A)
+  case object F32_ADD extends WasmSimpleInstr("f32.add", 0x92)
+  case object F32_SUB extends WasmSimpleInstr("f32.sub", 0x93)
+  case object F32_MUL extends WasmSimpleInstr("f32.mul", 0x94)
+  case object F32_DIV extends WasmSimpleInstr("f32.div", 0x95)
+  case object F32_MIN extends WasmSimpleInstr("f32.min", 0x96)
+  case object F32_MAX extends WasmSimpleInstr("f32.max", 0x97)
+  case object F32_COPYSIGN extends WasmSimpleInstr("f32.copysign", 0x98)
+  case object F64_ADD extends WasmSimpleInstr("f64.add", 0xA0)
+  case object F64_SUB extends WasmSimpleInstr("f64.sub", 0xA1)
+  case object F64_MUL extends WasmSimpleInstr("f64.mul", 0xA2)
+  case object F64_DIV extends WasmSimpleInstr("f64.div", 0xA3)
+  case object F64_MIN extends WasmSimpleInstr("f64.min", 0xA4)
+  case object F64_MAX extends WasmSimpleInstr("f64.max", 0xA5)
+
+  case class I32_CONST(v: I32) extends WasmInstr("i32.const", 0x41)
+  object I32_CONST { def apply(v: Int): I32_CONST = I32_CONST(I32(v)) }
+  case class I64_CONST(v: I64) extends WasmInstr("i64.const", 0x42)
+  object I64_CONST { def apply(v: Long): I64_CONST = I64_CONST(I64(v)) }
+  case class F32_CONST(v: F32) extends WasmInstr("f32.const", 0x43)
+  case class F64_CONST(v: F64) extends WasmInstr("f64.const", 0x44)
+
+  // Control instructions
+  // https://webassembly.github.io/spec/core/syntax/instructions.html#control-instructions
+  case object UNREACHABLE extends WasmSimpleInstr("unreachable", 0x00) with StackPolymorphicInstr
+  case object NOP extends WasmSimpleInstr("nop", 0x01)
   case class BLOCK(i: BlockType, label: Option[LabelIdx])
-      extends StructuredLabeledInstr("block", 0x02, List(i))
+      extends WasmBlockTypeLabeledInstr("block", 0x02, i)
   case class LOOP(i: BlockType, label: Option[LabelIdx])
-      extends StructuredLabeledInstr("loop", 0x03, List(i))
+      extends WasmBlockTypeLabeledInstr("loop", 0x03, i)
   case class IF(i: BlockType, label: Option[LabelIdx] = None)
-      extends StructuredLabeledInstr("if", 0x04, List(i))
-  case object ELSE extends WasmInstr("else", 0x05)
-  case object END extends WasmInstr("end", 0x0B)
-  case class BR(i: LabelIdx) extends WasmInstr("br", 0x0C, List(i)) with StackPolymorphicInstr
-  case class BR_IF(i: LabelIdx) extends WasmInstr("br_if", 0x0D, List(i))
+      extends WasmBlockTypeLabeledInstr("if", 0x04, i)
+  case object ELSE extends WasmSimpleInstr("else", 0x05)
+  case object END extends WasmSimpleInstr("end", 0x0B)
+  case class BR(i: LabelIdx) extends WasmLabelInstr("br", 0x0C, i) with StackPolymorphicInstr
+  case class BR_IF(i: LabelIdx) extends WasmLabelInstr("br_if", 0x0D, i)
   case class BR_TABLE(i: LabelIdxVector, default: LabelIdx)
-      extends WasmInstr("br_table", 0x0E, List(i, default))
+      extends WasmInstr("br_table", 0x0E)
       with StackPolymorphicInstr
-  case object RETURN extends WasmInstr("return", 0x0F) with StackPolymorphicInstr
-  case class CALL(i: FuncIdx) extends WasmInstr("call", 0x10, List(i))
-  case class THROW(i: TagIdx) extends WasmInstr("throw", 0x08, List(i)) with StackPolymorphicInstr
-  case object THROW_REF extends WasmInstr("throw_ref", 0x0A) with StackPolymorphicInstr
+  case object RETURN extends WasmSimpleInstr("return", 0x0F) with StackPolymorphicInstr
+  case class CALL(i: FuncIdx) extends WasmFuncInstr("call", 0x10, i)
+  case class THROW(i: TagIdx) extends WasmTagInstr("throw", 0x08, i) with StackPolymorphicInstr
+  case object THROW_REF extends WasmSimpleInstr("throw_ref", 0x0A) with StackPolymorphicInstr
   case class TRY_TABLE(i: BlockType, cs: CatchClauseVector, label: Option[LabelIdx] = None)
-      extends StructuredLabeledInstr("try_table", 0x1F, List(i, cs))
+      extends WasmInstr("try_table", 0x1F)
+      with StructuredLabeledInstr
 
   // Parametric instructions
   // https://webassembly.github.io/spec/core/syntax/instructions.html#parametric-instructions
-  case object DROP extends WasmInstr("drop", 0x1A)
+  case object DROP extends WasmSimpleInstr("drop", 0x1A)
   // TODO: SELECT
 
   // Variable instructions
   // https://webassembly.github.io/spec/core/syntax/instructions.html#variable-instructions
-  case class LOCAL_GET(i: LocalIdx) extends WasmInstr("local.get", 0x20, List(i))
-  case class LOCAL_SET(i: LocalIdx) extends WasmInstr("local.set", 0x21, List(i))
-  case class LOCAL_TEE(i: LocalIdx) extends WasmInstr("local.tee", 0x22, List(i))
-  case class GLOBAL_GET(i: GlobalIdx) extends WasmInstr("global.get", 0x23, List(i))
-  case class GLOBAL_SET(i: GlobalIdx) extends WasmInstr("global.set", 0x24, List(i))
+  case class LOCAL_GET(i: LocalIdx) extends WasmLocalInstr("local.get", 0x20, i)
+  case class LOCAL_SET(i: LocalIdx) extends WasmLocalInstr("local.set", 0x21, i)
+  case class LOCAL_TEE(i: LocalIdx) extends WasmLocalInstr("local.tee", 0x22, i)
+  case class GLOBAL_GET(i: GlobalIdx) extends WasmGlobalInstr("global.get", 0x23, i)
+  case class GLOBAL_SET(i: GlobalIdx) extends WasmGlobalInstr("global.set", 0x24, i)
 
   // Table instructions
   // https://webassembly.github.io/spec/core/syntax/instructions.html#table-instructions
@@ -212,72 +280,68 @@ object WasmInstr {
     *
     * `ref.null rt : [] -> [rtref]` (iff rt = func or rt = extern)
     */
-  case class REF_NULL(i: HeapType) extends WasmInstr("ref.null", 0xD0, List(i))
+  case class REF_NULL(i: HeapType) extends WasmHeapTypeInstr("ref.null", 0xD0, i)
 
   /** checks for null. ref.is_null : [rtref] -> [i32]
     */
-  case object REF_IS_NULL extends WasmInstr("ref.is_null", 0xD1)
+  case object REF_IS_NULL extends WasmSimpleInstr("ref.is_null", 0xD1)
 
   /** creates a reference to a given function. `ref.func $x : [] -> [funcref]` (iff $x : func $t)
     */
-  case class REF_FUNC(i: FuncIdx) extends WasmInstr("ref.func", 0xD2, List(i))
+  case class REF_FUNC(i: FuncIdx) extends WasmFuncInstr("ref.func", 0xD2, i)
   object REF_FUNC {
     def apply(i: WasmFunctionName): REF_FUNC = REF_FUNC(WasmImmediate.FuncIdx(i))
   }
 
-  case object REF_I31 extends WasmInstr("ref.i31", 0xFB1C)
-  case object I31_GET_S extends WasmInstr("i31.get_s", 0xFB1D)
-  case object I31_GET_U extends WasmInstr("i31.get_u", 0xFB1E)
+  case object REF_I31 extends WasmSimpleInstr("ref.i31", 0xFB1C)
+  case object I31_GET_S extends WasmSimpleInstr("i31.get_s", 0xFB1D)
+  case object I31_GET_U extends WasmSimpleInstr("i31.get_u", 0xFB1E)
 
   // ============================================================
   // Typed Function References
   // https://github.com/WebAssembly/function-references
-  case class CALL_REF(i: TypeIdx) extends WasmInstr("call_ref", 0x14, List(i))
-  case class RETURN_CALL_REF(i: TypeIdx) extends WasmInstr("return_call_ref", 0x15, List(i))
-  case object REF_AS_NOT_NULL extends WasmInstr("ref.as_non_null", 0xD4)
-  case class BR_ON_NULL(i: LabelIdx) extends WasmInstr("br_on_null", 0xD5, List(i))
-  case class BR_ON_NON_NULL(i: LabelIdx) extends WasmInstr("br_on_non_null", 0xD6, List(i))
+  case class CALL_REF(i: TypeIdx) extends WasmTypeInstr("call_ref", 0x14, i)
+  case class RETURN_CALL_REF(i: TypeIdx) extends WasmTypeInstr("return_call_ref", 0x15, i)
+  case object REF_AS_NOT_NULL extends WasmSimpleInstr("ref.as_non_null", 0xD4)
+  case class BR_ON_NULL(i: LabelIdx) extends WasmLabelInstr("br_on_null", 0xD5, i)
+  case class BR_ON_NON_NULL(i: LabelIdx) extends WasmLabelInstr("br_on_non_null", 0xD6, i)
 
   // ============================================================
   // gc
-  case class STRUCT_NEW(i: TypeIdx) extends WasmInstr("struct.new", 0xFB00, List(i))
+  case class STRUCT_NEW(i: TypeIdx) extends WasmTypeInstr("struct.new", 0xFB00, i)
   object STRUCT_NEW {
     def apply(i: WasmTypeName): STRUCT_NEW = STRUCT_NEW(WasmImmediate.TypeIdx(i))
   }
-  case class STRUCT_NEW_DEFAULT(i: TypeIdx) extends WasmInstr("struct.new_default", 0xFB01, List(i))
+  case class STRUCT_NEW_DEFAULT(i: TypeIdx) extends WasmTypeInstr("struct.new_default", 0xFB01, i)
   case class STRUCT_GET(tyidx: TypeIdx, fidx: StructFieldIdx)
-      extends WasmInstr("struct.get", 0xFB02, List(tyidx, fidx))
+      extends WasmStructFieldInstr("struct.get", 0xFB02, tyidx, fidx)
   // STRUCT_GET_S
   // STRUCT_GET_U
   case class STRUCT_SET(tyidx: TypeIdx, fidx: StructFieldIdx)
-      extends WasmInstr("struct.set", 0xFB05, List(tyidx, fidx))
+      extends WasmStructFieldInstr("struct.set", 0xFB05, tyidx, fidx)
 
-  case class ARRAY_NEW(i: TypeIdx) extends WasmInstr("array.new", 0xFB06, List(i))
-  case class ARRAY_NEW_DEFAULT(i: TypeIdx) extends WasmInstr("array.new_default", 0xFB07, List(i))
-  case class ARRAY_NEW_FIXED(i: TypeIdx, size: I32)
-      extends WasmInstr("array.new_fixed", 0xFB08, List(i, size))
-  case class ARRAY_NEW_DATA(i: TypeIdx, d: DataIdx)
-      extends WasmInstr("array.new_data", 0xFB09, List(i, d))
-  case class ARRAY_GET(i: TypeIdx) extends WasmInstr("array.get", 0xFB0B, List(i))
-  case class ARRAY_GET_S(i: TypeIdx) extends WasmInstr("array.get_s", 0xFB0C, List(i))
-  case class ARRAY_GET_U(i: TypeIdx) extends WasmInstr("array.get_u", 0xFB0D, List(i))
-  case class ARRAY_SET(i: TypeIdx) extends WasmInstr("array.set", 0xFB0E, List(i))
-  case object ARRAY_LEN extends WasmInstr("array.len", 0xFB0F)
+  case class ARRAY_NEW(i: TypeIdx) extends WasmTypeInstr("array.new", 0xFB06, i)
+  case class ARRAY_NEW_DEFAULT(i: TypeIdx) extends WasmTypeInstr("array.new_default", 0xFB07, i)
+  case class ARRAY_NEW_FIXED(i: TypeIdx, size: I32) extends WasmInstr("array.new_fixed", 0xFB08)
+  case class ARRAY_NEW_DATA(i: TypeIdx, d: DataIdx) extends WasmInstr("array.new_data", 0xFB09)
+  case class ARRAY_GET(i: TypeIdx) extends WasmTypeInstr("array.get", 0xFB0B, i)
+  case class ARRAY_GET_S(i: TypeIdx) extends WasmTypeInstr("array.get_s", 0xFB0C, i)
+  case class ARRAY_GET_U(i: TypeIdx) extends WasmTypeInstr("array.get_u", 0xFB0D, i)
+  case class ARRAY_SET(i: TypeIdx) extends WasmTypeInstr("array.set", 0xFB0E, i)
+  case object ARRAY_LEN extends WasmSimpleInstr("array.len", 0xFB0F)
   // ARRAY_FILL,
   // ARRAY_COPY
   // ARRAY_NEW_DATA
   // array_NEW_FIXED
 
-  case object REF_EQ extends WasmInstr("ref.eq", 0xD3)
-  case class REF_TEST(i: HeapType) extends WasmInstr("ref.test", 0xFB14, List(i))
-  case class REF_TEST_NULL(i: HeapType) extends WasmInstr("ref.test", 0xFB15, List(i))
-  case class REF_CAST(i: HeapType) extends WasmInstr("ref.cast", 0xFB16, List(i))
-  case class REF_CAST_NULL(i: HeapType) extends WasmInstr("ref.cast", 0xFB17, List(i))
+  case object REF_EQ extends WasmSimpleInstr("ref.eq", 0xD3)
+  case class REF_TEST(i: WasmRefType) extends WasmRefTypeInstr("ref.test", 0xFB14, 0xFB15, i)
+  case class REF_CAST(i: WasmRefType) extends WasmRefTypeInstr("ref.cast", 0xFB16, 0xFB17, i)
 
-  case class BR_ON_CAST(castFlags: CastFlags, label: LabelIdx, from: HeapType, to: HeapType)
-      extends WasmInstr("br_on_cast", 0xFB18, List(castFlags, label, from, to))
-  case class BR_ON_CAST_FAIL(castFlags: CastFlags, label: LabelIdx, from: HeapType, to: HeapType)
-      extends WasmInstr("br_on_cast_fail", 0xFB19, List(castFlags, label, from, to))
+  case class BR_ON_CAST(label: LabelIdx, from: WasmRefType, to: WasmRefType)
+      extends WasmInstr("br_on_cast", 0xFB18)
+  case class BR_ON_CAST_FAIL(label: LabelIdx, from: WasmRefType, to: WasmRefType)
+      extends WasmInstr("br_on_cast_fail", 0xFB19)
 }
 
 abstract sealed trait WasmImmediate
@@ -323,23 +387,17 @@ object WasmImmediate {
 
   case class CatchClauseVector(val value: List[CatchClause]) extends WasmImmediate
 
-  /** `castflags` for `br_on_cast` and `br_on_cast_fail`.
-    *
-    * @see
-    *   https://webassembly.github.io/gc/core/binary/instructions.html#control-instructions
-    */
-  case class CastFlags(nullable1: Boolean, nullable2: Boolean) extends WasmImmediate
-
   sealed abstract class CatchClause(
       val mnemonic: String,
       val opcode: Int,
-      val immediates: List[WasmImmediate]
+      val tag: Option[TagIdx],
+      val label: LabelIdx
   )
 
   object CatchClause {
-    case class Catch(x: TagIdx, l: LabelIdx) extends CatchClause("catch", 0x00, List(x, l))
-    case class CatchRef(x: TagIdx, l: LabelIdx) extends CatchClause("catch_ref", 0x01, List(x, l))
-    case class CatchAll(l: LabelIdx) extends CatchClause("catch_all", 0x02, List(l))
-    case class CatchAllRef(l: LabelIdx) extends CatchClause("catch_all_ref", 0x03, List(l))
+    case class Catch(x: TagIdx, l: LabelIdx) extends CatchClause("catch", 0x00, Some(x), l)
+    case class CatchRef(x: TagIdx, l: LabelIdx) extends CatchClause("catch_ref", 0x01, Some(x), l)
+    case class CatchAll(l: LabelIdx) extends CatchClause("catch_all", 0x02, None, l)
+    case class CatchAllRef(l: LabelIdx) extends CatchClause("catch_all_ref", 0x03, None, l)
   }
 }

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -8,8 +8,6 @@ import Names.WasmTypeName._
 sealed abstract class WasmInstr(val mnemonic: String, val opcode: Int)
 
 object WasmInstr {
-  import WasmImmediate._
-
   // Semantic categories of instructions
 
   /** A stack-polymorphic instruction. */
@@ -365,9 +363,8 @@ object WasmInstr {
     case class CatchAll(l: WasmLabelName) extends CatchClause("catch_all", 0x02, None, l)
     case class CatchAllRef(l: WasmLabelName) extends CatchClause("catch_all_ref", 0x03, None, l)
   }
-}
 
-object WasmImmediate {
+  // Block types
 
   /** A structured instruction can consume input and produce output on the operand stack according
     * to its annotated block type. It is given either as a type index that refers to a suitable
@@ -376,10 +373,10 @@ object WasmImmediate {
     * @see
     *   https://webassembly.github.io/spec/core/syntax/instructions.html#control-instructions
     */
-  abstract sealed trait BlockType
+  sealed abstract class BlockType
   object BlockType {
     case class FunctionType(ty: WasmFunctionTypeName) extends BlockType
-    case class ValueType private (ty: Option[WasmType]) extends BlockType
+    case class ValueType(ty: Option[WasmType]) extends BlockType
     object ValueType {
       def apply(ty: WasmType): ValueType = ValueType(Some(ty))
       def apply(): ValueType = ValueType(None)

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -181,8 +181,6 @@ object WasmInstr {
       with StackPolymorphicInstr
   case object RETURN extends WasmInstr("return", 0x0F) with StackPolymorphicInstr
   case class CALL(i: FuncIdx) extends WasmInstr("call", 0x10, List(i))
-  case class CALL_INDIRECT(i: TableIdx, t: TypeIdx)
-      extends WasmInstr("call_indirect", 0x11, List(i, t))
   case class THROW(i: TagIdx) extends WasmInstr("throw", 0x08, List(i)) with StackPolymorphicInstr
   case object THROW_REF extends WasmInstr("throw_ref", 0x0A) with StackPolymorphicInstr
   case class TRY_TABLE(i: BlockType, cs: CatchClauseVector, label: Option[LabelIdx] = None)
@@ -311,7 +309,6 @@ object WasmImmediate {
   case class LabelIdxVector(val value: List[LabelIdx]) extends WasmImmediate
   case class TypeIdx(val value: WasmTypeName) extends WasmImmediate
   case class DataIdx(val value: WasmDataName) extends WasmImmediate
-  case class TableIdx(val value: Int) extends WasmImmediate
   case class TagIdx(val value: WasmTagName) extends WasmImmediate
   case class LocalIdx(val value: WasmLocalName) extends WasmImmediate
   case class GlobalIdx(val value: WasmGlobalName) extends WasmImmediate

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -331,10 +331,7 @@ object WasmImmediate {
     case class FunctionType(ty: WasmFunctionTypeName) extends BlockType
     case class ValueType private (ty: Option[WasmType]) extends BlockType
     object ValueType {
-      def apply(ty: WasmType): ValueType = ty match {
-        case WasmNoType => ValueType(None)
-        case _          => ValueType(Some(ty))
-      }
+      def apply(ty: WasmType): ValueType = ValueType(Some(ty))
       def apply(): ValueType = ValueType(None)
     }
   }

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -344,6 +344,23 @@ object WasmInstr {
       extends WasmInstr("br_on_cast", 0xFB18)
   case class BR_ON_CAST_FAIL(label: LabelIdx, from: WasmRefType, to: WasmRefType)
       extends WasmInstr("br_on_cast_fail", 0xFB19)
+
+  // Catch clauses for TRY_TABLE
+
+  sealed abstract class CatchClause(
+      val mnemonic: String,
+      val opcode: Int,
+      val tag: Option[WasmTagName],
+      val label: LabelIdx
+  )
+
+  object CatchClause {
+    case class Catch(x: WasmTagName, l: LabelIdx) extends CatchClause("catch", 0x00, Some(x), l)
+    case class CatchRef(x: WasmTagName, l: LabelIdx)
+        extends CatchClause("catch_ref", 0x01, Some(x), l)
+    case class CatchAll(l: LabelIdx) extends CatchClause("catch_all", 0x02, None, l)
+    case class CatchAllRef(l: LabelIdx) extends CatchClause("catch_all_ref", 0x03, None, l)
+  }
 }
 
 object WasmImmediate {
@@ -372,20 +389,5 @@ object WasmImmediate {
     val vtable = StructFieldIdx(0)
     val itables = StructFieldIdx(1)
     val uniqueRegularField = StructFieldIdx(2)
-  }
-
-  sealed abstract class CatchClause(
-      val mnemonic: String,
-      val opcode: Int,
-      val tag: Option[WasmTagName],
-      val label: LabelIdx
-  )
-
-  object CatchClause {
-    case class Catch(x: WasmTagName, l: LabelIdx) extends CatchClause("catch", 0x00, Some(x), l)
-    case class CatchRef(x: WasmTagName, l: LabelIdx)
-        extends CatchClause("catch_ref", 0x01, Some(x), l)
-    case class CatchAll(l: LabelIdx) extends CatchClause("catch_all", 0x02, None, l)
-    case class CatchAllRef(l: LabelIdx) extends CatchClause("catch_all_ref", 0x03, None, l)
   }
 }

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -154,33 +154,6 @@ object WasmInstr {
   case class F32_CONST(v: F32) extends WasmInstr("f32.const", 0x43, List(v))
   case class F64_CONST(v: F64) extends WasmInstr("f64.const", 0x44, List(v))
 
-  // Memory instructions
-  // https://webassembly.github.io/spec/core/syntax/instructions.html#memory-instructions
-  case class I32_LOAD(v: MemArg) extends WasmInstr("i32.load", 0x28, List(v))
-  case class I64_LOAD(v: MemArg) extends WasmInstr("i64.load", 0x29, List(v))
-  case class F32_LOAD(v: MemArg) extends WasmInstr("f32.load", 0x2A, List(v))
-  case class F64_LOAD(v: MemArg) extends WasmInstr("f64.load", 0x2B, List(v))
-  case class I32_LOAD8_S(v: MemArg) extends WasmInstr("i32.load8_s", 0x2C, List(v))
-  case class I32_LOAD8_U(v: MemArg) extends WasmInstr("i32.load8_u", 0x2D, List(v))
-  case class I32_LOAD16_S(v: MemArg) extends WasmInstr("i32.load16_s", 0x2E, List(v))
-  case class I32_LOAD16_U(v: MemArg) extends WasmInstr("i32.load16_u", 0x2F, List(v))
-  case class I64_LOAD8_S(v: MemArg) extends WasmInstr("i64.load8_s", 0x30, List(v))
-  case class I64_LOAD8_U(v: MemArg) extends WasmInstr("i64.load8_u", 0x31, List(v))
-  case class I64_LOAD16_S(v: MemArg) extends WasmInstr("i64.load16_s", 0x32, List(v))
-  case class I64_LOAD16_U(v: MemArg) extends WasmInstr("i64.load16_u", 0x33, List(v))
-  case class I64_LOAD32_S(v: MemArg) extends WasmInstr("i64.load32_s", 0x34, List(v))
-  case class I64_LOAD32_U(v: MemArg) extends WasmInstr("i64.load32_u", 0x35, List(v))
-
-  case class I32_STORE(v: MemArg) extends WasmInstr("i32.store", 0x36, List(v))
-  case class I64_STORE(v: MemArg) extends WasmInstr("i64.store", 0x37, List(v))
-  case class F32_STORE(v: MemArg) extends WasmInstr("f32.store", 0x38, List(v))
-  case class F64_STORE(v: MemArg) extends WasmInstr("f64.store", 0x39, List(v))
-  case class I32_STORE8(v: MemArg) extends WasmInstr("i32.store8", 0x3A, List(v))
-  case class I32_STORE16(v: MemArg) extends WasmInstr("i32.store16", 0x3B, List(v))
-  case class I64_STORE8(v: MemArg) extends WasmInstr("i64.store8", 0x3C, List(v))
-  case class I64_STORE16(v: MemArg) extends WasmInstr("i64.store16", 0x3D, List(v))
-  case class I64_STORE32(v: MemArg) extends WasmInstr("i64.store32", 0x3E, List(v))
-
   // Control instructions
   // https://webassembly.github.io/spec/core/syntax/instructions.html#control-instructions
   sealed abstract class StructuredLabeledInstr(
@@ -315,9 +288,6 @@ object WasmImmediate {
   case class I64(value: Long) extends WasmImmediate
   case class F32(value: Float) extends WasmImmediate
   case class F64(value: Double) extends WasmImmediate
-
-  // TODO: UInt
-  case class MemArg(offset: Long, align: Long) extends WasmImmediate
 
   /** A structured instruction can consume input and produce output on the operand stack according
     * to its annotated block type. It is given either as a type index that refers to a suitable

--- a/wasm/src/main/scala/wasm4s/Names.scala
+++ b/wasm/src/main/scala/wasm4s/Names.scala
@@ -36,6 +36,12 @@ object Names {
     val receiver = new WasmLocalName("___<this>")
   }
 
+  final case class WasmLabelName private (override private[wasm4s] val name: String)
+      extends WasmName(name)
+  object WasmLabelName {
+    def synthetic(id: Int): WasmLabelName = new WasmLabelName(id.toString())
+  }
+
   final case class WasmGlobalName private (override private[wasm4s] val name: String)
       extends WasmName(name)
   object WasmGlobalName {
@@ -348,16 +354,26 @@ object Names {
         * is instantiated only with the classes that implement java.lang.Cloneable.
         */
       val cloneFunction = new WasmFieldName("clone")
+    }
+  }
 
-      val nameDataIdx = WasmImmediate.StructFieldIdx(0)
-      val kindIdx = WasmImmediate.StructFieldIdx(1)
-      val specialInstanceTypesIdx = WasmImmediate.StructFieldIdx(2)
-      val strictAncestorsIdx = WasmImmediate.StructFieldIdx(3)
-      val componentTypeIdx = WasmImmediate.StructFieldIdx(4)
-      val nameIdx = WasmImmediate.StructFieldIdx(5)
-      val classOfIdx = WasmImmediate.StructFieldIdx(6)
-      val arrayOfIdx = WasmImmediate.StructFieldIdx(7)
-      val cloneFunctionIdx = WasmImmediate.StructFieldIdx(8)
+  final case class WasmFieldIdx(value: Int)
+
+  object WasmFieldIdx {
+    val vtable = WasmFieldIdx(0)
+    val itables = WasmFieldIdx(1)
+    val uniqueRegularField = WasmFieldIdx(2)
+
+    object typeData {
+      val nameDataIdx = WasmFieldIdx(0)
+      val kindIdx = WasmFieldIdx(1)
+      val specialInstanceTypesIdx = WasmFieldIdx(2)
+      val strictAncestorsIdx = WasmFieldIdx(3)
+      val componentTypeIdx = WasmFieldIdx(4)
+      val nameIdx = WasmFieldIdx(5)
+      val classOfIdx = WasmFieldIdx(6)
+      val arrayOfIdx = WasmFieldIdx(7)
+      val cloneFunctionIdx = WasmFieldIdx(8)
     }
   }
 

--- a/wasm/src/main/scala/wasm4s/Types.scala
+++ b/wasm/src/main/scala/wasm4s/Types.scala
@@ -16,9 +16,6 @@ object Types {
 
   abstract sealed class WasmType(name: String, code: Byte) extends WasmStorageType(name, code)
 
-  // todo
-  case object WasmNoType extends WasmType("", 0x00)
-
   // case object WasmTypeNone extends WasmType
   case object WasmUnreachableType extends WasmType("unreachable", -0x40)
   case object WasmInt32 extends WasmType("i32", 0x7F)

--- a/wasm/src/main/scala/wasm4s/Wasm.scala
+++ b/wasm/src/main/scala/wasm4s/Wasm.scala
@@ -108,7 +108,7 @@ object WasmStructType {
     List(
       WasmStructField(
         WasmFieldName.typeData.nameData,
-        WasmRefNullType(WasmHeapType.Type(WasmArrayTypeName.i16Array)),
+        WasmRefType.nullable(WasmArrayTypeName.i16Array),
         isMutable = false
       ),
       WasmStructField(
@@ -123,32 +123,32 @@ object WasmStructType {
       ),
       WasmStructField(
         WasmFieldName.typeData.strictAncestors,
-        WasmRefNullType(WasmHeapType.Type(WasmTypeName.WasmArrayTypeName.typeDataArray)),
+        WasmRefType.nullable(WasmTypeName.WasmArrayTypeName.typeDataArray),
         isMutable = false
       ),
       WasmStructField(
         WasmFieldName.typeData.componentType,
-        WasmRefNullType(WasmHeapType.Type(WasmTypeName.WasmStructTypeName.typeData)),
+        WasmRefType.nullable(WasmTypeName.WasmStructTypeName.typeData),
         isMutable = false
       ),
       WasmStructField(
         WasmFieldName.typeData.name,
-        WasmAnyRef,
+        WasmRefType.anyref,
         isMutable = true
       ),
       WasmStructField(
         WasmFieldName.typeData.classOfValue,
-        WasmRefNullType(WasmHeapType.ClassType),
+        WasmRefType.nullable(WasmHeapType.ClassType),
         isMutable = true
       ),
       WasmStructField(
         WasmFieldName.typeData.arrayOf,
-        WasmRefNullType(WasmHeapType.Type(WasmTypeName.WasmStructTypeName.ObjectVTable)),
+        WasmRefType.nullable(WasmTypeName.WasmStructTypeName.ObjectVTable),
         isMutable = true
       ),
       WasmStructField(
         WasmFieldName.typeData.cloneFunction,
-        WasmRefNullType(WasmHeapType.Type(ctx.cloneFunctionTypeName)),
+        WasmRefType.nullable(ctx.cloneFunctionTypeName),
         isMutable = false
       )
     ),
@@ -170,7 +170,7 @@ object WasmArrayType {
     WasmArrayTypeName.typeDataArray,
     WasmStructField(
       WasmFieldName.arrayItem,
-      WasmRefType(WasmHeapType.Type(WasmStructTypeName.typeData)),
+      WasmRefType(WasmStructTypeName.typeData),
       isMutable = false
     )
   )
@@ -180,7 +180,7 @@ object WasmArrayType {
     WasmArrayTypeName.itables,
     WasmStructField(
       WasmFieldName.itable,
-      WasmRefNullType(WasmHeapType.Simple.Struct),
+      WasmRefType.nullable(WasmHeapType.Struct),
       isMutable = true
     )
   )
@@ -224,7 +224,7 @@ object WasmArrayType {
   /** array anyref */
   val anyArray = WasmArrayType(
     WasmArrayTypeName.anyArray,
-    WasmStructField(WasmFieldName.arrayItem, WasmAnyRef, true)
+    WasmStructField(WasmFieldName.arrayItem, WasmRefType.anyref, true)
   )
 }
 
@@ -236,7 +236,7 @@ case class WasmStructField(
 object WasmStructField {
   val itables = WasmStructField(
     WasmFieldName.itables,
-    WasmRefNullType(WasmHeapType.Type(WasmArrayType.itables.name)),
+    WasmRefType.nullable(WasmArrayType.itables.name),
     isMutable = false
   )
 }

--- a/wasm/src/main/scala/wasm4s/WasmContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmContext.scala
@@ -252,6 +252,7 @@ trait TypeDefinableWasmContext extends ReadOnlyWasmContext { this: WasmContext =
 
 class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
   import WasmContext._
+  import WasmRefType.anyref
 
   private val _importedModules: mutable.LinkedHashSet[String] =
     new mutable.LinkedHashSet()
@@ -290,7 +291,7 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
         WasmImport(
           "__scalaJSImports",
           moduleName,
-          WasmImportDesc.Global(name, WasmAnyRef, isMutable = false)
+          WasmImportDesc.Global(name, anyref, isMutable = false)
         )
       )
     }
@@ -316,7 +317,7 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
   val exceptionTagName: WasmTagName = WasmTagName("exception")
 
   locally {
-    val exceptionSig = WasmFunctionSignature(List(WasmAnyRef), Nil)
+    val exceptionSig = WasmFunctionSignature(List(anyref), Nil)
     val exceptionFunType = addFunctionType(exceptionSig)
     module.addTag(WasmTag(exceptionTagName, exceptionFunType))
   }
@@ -333,10 +334,10 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
 
   addGCType(WasmStructType.typeData(this))
 
-  addHelperImport(WasmFunctionName.is, List(WasmAnyRef, WasmAnyRef), List(WasmInt32))
+  addHelperImport(WasmFunctionName.is, List(anyref, anyref), List(WasmInt32))
 
   addHelperImport(WasmFunctionName.undef, List(), List(WasmRefType.any))
-  addHelperImport(WasmFunctionName.isUndef, List(WasmAnyRef), List(WasmInt32))
+  addHelperImport(WasmFunctionName.isUndef, List(anyref), List(WasmInt32))
 
   locally {
     import IRTypes._
@@ -346,10 +347,10 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
         case DoubleRef => WasmFloat64
         case _         => WasmInt32
       }
-      addHelperImport(WasmFunctionName.box(primRef), List(wasmType), List(WasmAnyRef))
-      addHelperImport(WasmFunctionName.unbox(primRef), List(WasmAnyRef), List(wasmType))
-      addHelperImport(WasmFunctionName.unboxOrNull(primRef), List(WasmAnyRef), List(WasmAnyRef))
-      addHelperImport(WasmFunctionName.typeTest(primRef), List(WasmAnyRef), List(WasmInt32))
+      addHelperImport(WasmFunctionName.box(primRef), List(wasmType), List(anyref))
+      addHelperImport(WasmFunctionName.unbox(primRef), List(anyref), List(wasmType))
+      addHelperImport(WasmFunctionName.unboxOrNull(primRef), List(anyref), List(anyref))
+      addHelperImport(WasmFunctionName.typeTest(primRef), List(anyref), List(WasmInt32))
     }
   }
 
@@ -357,29 +358,29 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
 
   addHelperImport(
     WasmFunctionName.closure,
-    List(WasmRefType.func, WasmAnyRef),
+    List(WasmRefType.func, anyref),
     List(WasmRefType.any)
   )
   addHelperImport(
     WasmFunctionName.closureThis,
-    List(WasmRefType.func, WasmAnyRef),
+    List(WasmRefType.func, anyref),
     List(WasmRefType.any)
   )
   addHelperImport(
     WasmFunctionName.closureRest,
-    List(WasmRefType.func, WasmAnyRef, WasmInt32),
+    List(WasmRefType.func, anyref, WasmInt32),
     List(WasmRefType.any)
   )
   addHelperImport(
     WasmFunctionName.closureThisRest,
-    List(WasmRefType.func, WasmAnyRef, WasmInt32),
+    List(WasmRefType.func, anyref, WasmInt32),
     List(WasmRefType.any)
   )
 
   addHelperImport(WasmFunctionName.emptyString, List(), List(WasmRefType.any))
   addHelperImport(WasmFunctionName.stringLength, List(WasmRefType.any), List(WasmInt32))
   addHelperImport(WasmFunctionName.stringCharAt, List(WasmRefType.any, WasmInt32), List(WasmInt32))
-  addHelperImport(WasmFunctionName.jsValueToString, List(WasmAnyRef), List(WasmRefType.any))
+  addHelperImport(WasmFunctionName.jsValueToString, List(anyref), List(WasmRefType.any))
   addHelperImport(WasmFunctionName.booleanToString, List(WasmInt32), List(WasmRefType.any))
   addHelperImport(WasmFunctionName.charToString, List(WasmInt32), List(WasmRefType.any))
   addHelperImport(WasmFunctionName.intToString, List(WasmInt32), List(WasmRefType.any))
@@ -390,93 +391,93 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
     List(WasmRefType.any, WasmRefType.any),
     List(WasmRefType.any)
   )
-  addHelperImport(WasmFunctionName.isString, List(WasmAnyRef), List(WasmInt32))
+  addHelperImport(WasmFunctionName.isString, List(anyref), List(WasmInt32))
 
   addHelperImport(WasmFunctionName.jsValueType, List(WasmRefType.any), List(WasmInt32))
   addHelperImport(WasmFunctionName.jsValueHashCode, List(WasmRefType.any), List(WasmInt32))
 
-  addHelperImport(WasmFunctionName.jsGlobalRefGet, List(WasmRefType.any), List(WasmAnyRef))
-  addHelperImport(WasmFunctionName.jsGlobalRefSet, List(WasmRefType.any, WasmAnyRef), Nil)
+  addHelperImport(WasmFunctionName.jsGlobalRefGet, List(WasmRefType.any), List(anyref))
+  addHelperImport(WasmFunctionName.jsGlobalRefSet, List(WasmRefType.any, anyref), Nil)
   addHelperImport(WasmFunctionName.jsGlobalRefTypeof, List(WasmRefType.any), List(WasmRefType.any))
-  addHelperImport(WasmFunctionName.jsNewArray, Nil, List(WasmAnyRef))
-  addHelperImport(WasmFunctionName.jsArrayPush, List(WasmAnyRef, WasmAnyRef), List(WasmAnyRef))
+  addHelperImport(WasmFunctionName.jsNewArray, Nil, List(anyref))
+  addHelperImport(WasmFunctionName.jsArrayPush, List(anyref, anyref), List(anyref))
   addHelperImport(
     WasmFunctionName.jsArraySpreadPush,
-    List(WasmAnyRef, WasmAnyRef),
-    List(WasmAnyRef)
+    List(anyref, anyref),
+    List(anyref)
   )
-  addHelperImport(WasmFunctionName.jsNewObject, Nil, List(WasmAnyRef))
+  addHelperImport(WasmFunctionName.jsNewObject, Nil, List(anyref))
   addHelperImport(
     WasmFunctionName.jsObjectPush,
-    List(WasmAnyRef, WasmAnyRef, WasmAnyRef),
-    List(WasmAnyRef)
+    List(anyref, anyref, anyref),
+    List(anyref)
   )
-  addHelperImport(WasmFunctionName.jsSelect, List(WasmAnyRef, WasmAnyRef), List(WasmAnyRef))
-  addHelperImport(WasmFunctionName.jsSelectSet, List(WasmAnyRef, WasmAnyRef, WasmAnyRef), Nil)
-  addHelperImport(WasmFunctionName.jsNew, List(WasmAnyRef, WasmAnyRef), List(WasmAnyRef))
-  addHelperImport(WasmFunctionName.jsFunctionApply, List(WasmAnyRef, WasmAnyRef), List(WasmAnyRef))
+  addHelperImport(WasmFunctionName.jsSelect, List(anyref, anyref), List(anyref))
+  addHelperImport(WasmFunctionName.jsSelectSet, List(anyref, anyref, anyref), Nil)
+  addHelperImport(WasmFunctionName.jsNew, List(anyref, anyref), List(anyref))
+  addHelperImport(WasmFunctionName.jsFunctionApply, List(anyref, anyref), List(anyref))
   addHelperImport(
     WasmFunctionName.jsMethodApply,
-    List(WasmAnyRef, WasmAnyRef, WasmAnyRef),
-    List(WasmAnyRef)
+    List(anyref, anyref, anyref),
+    List(anyref)
   )
-  addHelperImport(WasmFunctionName.jsImportCall, List(WasmAnyRef), List(WasmAnyRef))
-  addHelperImport(WasmFunctionName.jsImportMeta, Nil, List(WasmAnyRef))
-  addHelperImport(WasmFunctionName.jsDelete, List(WasmAnyRef, WasmAnyRef), Nil)
-  addHelperImport(WasmFunctionName.jsForInSimple, List(WasmAnyRef, WasmAnyRef), Nil)
-  addHelperImport(WasmFunctionName.jsIsTruthy, List(WasmAnyRef), List(WasmInt32))
-  addHelperImport(WasmFunctionName.jsLinkingInfo, Nil, List(WasmAnyRef))
+  addHelperImport(WasmFunctionName.jsImportCall, List(anyref), List(anyref))
+  addHelperImport(WasmFunctionName.jsImportMeta, Nil, List(anyref))
+  addHelperImport(WasmFunctionName.jsDelete, List(anyref, anyref), Nil)
+  addHelperImport(WasmFunctionName.jsForInSimple, List(anyref, anyref), Nil)
+  addHelperImport(WasmFunctionName.jsIsTruthy, List(anyref), List(WasmInt32))
+  addHelperImport(WasmFunctionName.jsLinkingInfo, Nil, List(anyref))
 
   for ((op, name) <- WasmFunctionName.jsUnaryOps)
-    addHelperImport(name, List(WasmAnyRef), List(WasmAnyRef))
+    addHelperImport(name, List(anyref), List(anyref))
 
   for ((op, name) <- WasmFunctionName.jsBinaryOps) {
     val resultType =
       if (op == IRTrees.JSBinaryOp.=== || op == IRTrees.JSBinaryOp.!==) WasmInt32
-      else WasmAnyRef
-    addHelperImport(name, List(WasmAnyRef, WasmAnyRef), List(resultType))
+      else anyref
+    addHelperImport(name, List(anyref, anyref), List(resultType))
   }
 
-  addHelperImport(WasmFunctionName.newSymbol, Nil, List(WasmAnyRef))
+  addHelperImport(WasmFunctionName.newSymbol, Nil, List(anyref))
   addHelperImport(
     WasmFunctionName.createJSClass,
-    List(WasmAnyRef, WasmAnyRef, WasmRefType.func, WasmRefType.func, WasmRefType.func),
+    List(anyref, anyref, WasmRefType.func, WasmRefType.func, WasmRefType.func),
     List(WasmRefType.any)
   )
   addHelperImport(
     WasmFunctionName.createJSClassRest,
-    List(WasmAnyRef, WasmAnyRef, WasmRefType.func, WasmRefType.func, WasmRefType.func, WasmInt32),
+    List(anyref, anyref, WasmRefType.func, WasmRefType.func, WasmRefType.func, WasmInt32),
     List(WasmRefType.any)
   )
   addHelperImport(
     WasmFunctionName.installJSField,
-    List(WasmAnyRef, WasmAnyRef, WasmAnyRef),
+    List(anyref, anyref, anyref),
     Nil
   )
   addHelperImport(
     WasmFunctionName.installJSMethod,
-    List(WasmAnyRef, WasmAnyRef, WasmInt32, WasmAnyRef, WasmRefType.func, WasmInt32),
+    List(anyref, anyref, WasmInt32, anyref, WasmRefType.func, WasmInt32),
     Nil
   )
   addHelperImport(
     WasmFunctionName.installJSProperty,
-    List(WasmAnyRef, WasmAnyRef, WasmInt32, WasmAnyRef, WasmFuncRef, WasmFuncRef),
+    List(anyref, anyref, WasmInt32, anyref, WasmRefType.funcref, WasmRefType.funcref),
     Nil
   )
   addHelperImport(
     WasmFunctionName.jsSuperGet,
-    List(WasmAnyRef, WasmAnyRef, WasmAnyRef),
-    List(WasmAnyRef)
+    List(anyref, anyref, anyref),
+    List(anyref)
   )
   addHelperImport(
     WasmFunctionName.jsSuperSet,
-    List(WasmAnyRef, WasmAnyRef, WasmAnyRef, WasmAnyRef),
+    List(anyref, anyref, anyref, anyref),
     Nil
   )
   addHelperImport(
     WasmFunctionName.jsSuperCall,
-    List(WasmAnyRef, WasmAnyRef, WasmAnyRef, WasmAnyRef),
-    List(WasmAnyRef)
+    List(anyref, anyref, anyref, anyref),
+    List(anyref)
   )
 
   def complete(
@@ -500,7 +501,7 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
     addGlobal(
       WasmGlobal(
         WasmGlobalName.stringLiteralCache,
-        WasmRefType(WasmHeapType.Type(WasmArrayTypeName.anyArray)),
+        WasmRefType(WasmArrayTypeName.anyArray),
         WasmExpr(
           List(
             WasmInstr.I32_CONST(WasmImmediate.I32(nextConstantStringIndex)),
@@ -619,7 +620,7 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
       val exprs = _funcDeclarations.toList.map { name =>
         WasmExpr(List(WasmInstr.REF_FUNC(WasmImmediate.FuncIdx(name))))
       }
-      module.addElement(WasmElement(WasmFuncRef, exprs, WasmElement.Mode.Declarative))
+      module.addElement(WasmElement(WasmRefType.funcref, exprs, WasmElement.Mode.Declarative))
     }
   }
 }

--- a/wasm/src/main/scala/wasm4s/WasmContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmContext.scala
@@ -709,8 +709,8 @@ object WasmContext {
       }
     }
 
-    def getFieldIdx(name: IRNames.FieldName): WasmImmediate.StructFieldIdx = {
-      WasmImmediate.StructFieldIdx(
+    def getFieldIdx(name: IRNames.FieldName): WasmFieldIdx = {
+      WasmFieldIdx(
         fieldIdxByName.getOrElse(
           name, {
             throw new AssertionError(

--- a/wasm/src/main/scala/wasm4s/WasmFunctionContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmFunctionContext.scala
@@ -8,7 +8,6 @@ import org.scalajs.ir.{Trees => IRTrees}
 
 import wasm.wasm4s.Names._
 import wasm.wasm4s.Types.WasmType
-import wasm.wasm4s.WasmImmediate.BlockType
 import wasm.wasm4s.WasmInstr._
 
 import wasm.ir2wasm.TypeTransformer

--- a/wasm/src/main/scala/wasm4s/WasmFunctionContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmFunctionContext.scala
@@ -142,6 +142,12 @@ class WasmFunctionContext private (
   def ifThenElse(resultType: WasmType)(thenp: => Unit)(elsep: => Unit): Unit =
     ifThenElse(BlockType.ValueType(resultType))(thenp)(elsep)
 
+  def ifThenElse(sig: WasmFunctionSignature)(thenp: => Unit)(elsep: => Unit): Unit =
+    ifThenElse(sigToBlockType(sig))(thenp)(elsep)
+
+  def ifThenElse(resultTypes: List[WasmType])(thenp: => Unit)(elsep: => Unit): Unit =
+    ifThenElse(WasmFunctionSignature(Nil, resultTypes))(thenp)(elsep)
+
   def ifThenElse()(thenp: => Unit)(elsep: => Unit): Unit =
     ifThenElse(BlockType.ValueType())(thenp)(elsep)
 
@@ -153,6 +159,9 @@ class WasmFunctionContext private (
 
   def ifThen(sig: WasmFunctionSignature)(thenp: => Unit): Unit =
     ifThen(sigToBlockType(sig))(thenp)
+
+  def ifThen(resultTypes: List[WasmType])(thenp: => Unit): Unit =
+    ifThen(WasmFunctionSignature(Nil, resultTypes))(thenp)
 
   def ifThen()(thenp: => Unit): Unit =
     ifThen(BlockType.ValueType())(thenp)

--- a/wasm/src/main/scala/wasm4s/WasmFunctionContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmFunctionContext.scala
@@ -455,7 +455,7 @@ object WasmFunctionContext {
           val dataStructType = ctx.getClosureDataStructType(captureLikes.map(_._2))
           val local = WasmLocal(
             WasmLocalName(captureParamName),
-            Types.WasmRefType(Types.WasmHeapType.Type(dataStructType.name)),
+            Types.WasmRefType(dataStructType.name),
             isParameter = true
           )
           val localIdx = LocalIdx(local.name)
@@ -487,7 +487,7 @@ object WasmFunctionContext {
 
     val newTarget =
       if (!hasNewTarget) None
-      else Some(WasmLocal(WasmLocalName.newTarget, Types.WasmAnyRef, isParameter = true))
+      else Some(WasmLocal(WasmLocalName.newTarget, Types.WasmRefType.anyref, isParameter = true))
     val newTargetStorage = newTarget.map(local => VarStorage.Local(LocalIdx(local.name)))
 
     val receiver = receiverTyp.map { typ =>

--- a/wasm/src/main/scala/wasm4s/WasmFunctionContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmFunctionContext.scala
@@ -216,27 +216,23 @@ class WasmFunctionContext private (
     }
   }
 
-  def tryTable[A](blockType: BlockType)(clauses: List[WasmImmediate.CatchClause])(body: => A): A = {
+  def tryTable[A](blockType: BlockType)(clauses: List[CatchClause])(body: => A): A = {
     instrs += TRY_TABLE(blockType, clauses)
     val result = body
     instrs += END
     result
   }
 
-  def tryTable[A](resultType: WasmType)(clauses: List[WasmImmediate.CatchClause])(body: => A): A =
+  def tryTable[A](resultType: WasmType)(clauses: List[CatchClause])(body: => A): A =
     tryTable(BlockType.ValueType(resultType))(clauses)(body)
 
-  def tryTable[A]()(clauses: List[WasmImmediate.CatchClause])(body: => A): A =
+  def tryTable[A]()(clauses: List[CatchClause])(body: => A): A =
     tryTable(BlockType.ValueType())(clauses)(body)
 
-  def tryTable[A](sig: WasmFunctionSignature)(clauses: List[WasmImmediate.CatchClause])(
-      body: => A
-  ): A =
+  def tryTable[A](sig: WasmFunctionSignature)(clauses: List[CatchClause])(body: => A): A =
     tryTable(sigToBlockType(sig))(clauses)(body)
 
-  def tryTable[A](
-      resultTypes: List[WasmType]
-  )(clauses: List[WasmImmediate.CatchClause])(body: => A): A =
+  def tryTable[A](resultTypes: List[WasmType])(clauses: List[CatchClause])(body: => A): A =
     tryTable(WasmFunctionSignature(Nil, resultTypes))(clauses)(body)
 
   /** Builds a `switch` over a scrutinee using a `br_table` instruction.


### PR DESCRIPTION
Overall, these changes bring our model closer to the "Structure" view of the WebAssembly specification, as opposed to the "Binary format" view of the spec. They also remove several levels of nesting of data structures, which makes the code less unwieldy.