### PR TITLE
Fix static type tests for ancestors of hijacked classes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -228,8 +228,6 @@ lazy val IgnoredTestNames: Set[String] = {
   Set(
     // reflective call: should be throw an exception when reflective proxy not found
     "org.scalajs.testsuite.compiler.WasPublicBeforeTyperTestScala2",
-    // javaLangNumber failed: java.lang.AssertionError: 1, class java.lang.Number expected:<true> but was:<false>
-    "org.scalajs.testsuite.compiler.RuntimeTypeTestsTest",
     // Various run-time errors and JS exceptions
     "org.scalajs.testsuite.compiler.InteroperabilityTest",
     "org.scalajs.testsuite.compiler.RegressionJSTest",
@@ -242,8 +240,6 @@ lazy val IgnoredTestNames: Set[String] = {
     "org.scalajs.testsuite.compiler.ReflectionTest",
     "org.scalajs.testsuite.compiler.RuntimeTypeTestsJSTest",
     "org.scalajs.testsuite.jsinterop.ModulesTest",
-    // eqEqJLFloat/eqEqJLDouble failed: java.lang.AssertionError: null
-    "org.scalajs.testsuite.compiler.RegressionTest",
     // TypeError: WebAssembly objects are opaque
     "org.scalajs.testsuite.javalib.lang.SystemJSTest",
     // throwablesAreTrueErrors failed: org.junit.ComparisonFailure: expected:<[object [Error]]> but was:<[object [Object]]>
@@ -251,8 +247,6 @@ lazy val IgnoredTestNames: Set[String] = {
     "org.scalajs.testsuite.javalib.lang.ThrowableJSTest",
     // keepBreakToLabelWithinFinallyBlock_Issue2689 failed: java.lang.AssertionError: expected:<2> but was:<1>
     "org.scalajs.testsuite.compiler.OptimizerTest",
-    // nonUnitBoxedPrimitiveValuesAreSerializable failed: java.lang.AssertionError: Boolean
-    "org.scalajs.testsuite.javalib.io.SerializableTest",
     // No support for stack traces
     "org.scalajs.testsuite.library.StackTraceTest",
   )


### PR DESCRIPTION
This commit fixes the result of `x.isInstanceOf[C]` where `x` is a primitive and `C` is an ancestor of the hijacked class for `x`.

For `jl.Number`, which is the only non-`Object` class that is an ancestor of a hijacked class, we add a special case in the codegen.

For interfaces, we add generic code in their `genInstanceTest` function, based on their `specialInstanceTypes`.

This means we have a second place where we need to compute `specialInstanceTypes`. We move it to the preprocessor, and also use it to generically compute `isAncestorOfHijackedClass`. This removes the hard-code set that we had before.

Fix #74.
Fix #84.
Fix #92.