### PR TITLE
Generate source maps.

### DIFF
--- a/wasm/src/main/scala/converters/WasmTextWriter.scala
+++ b/wasm/src/main/scala/converters/WasmTextWriter.scala
@@ -329,23 +329,30 @@ class WasmTextWriter {
 
   private def writeInstr(instr: WasmInstr)(implicit b: WatBuilder): Unit = {
     instr match {
-      case END | ELSE | _: CATCH | CATCH_ALL => b.deindent()
-      case _                                 => ()
-    }
-    b.newLine()
-    b.appendElement(instr.mnemonic)
-    instr match {
-      case instr: StructuredLabeledInstr =>
-        instr.label.foreach(writeLabelIdx(_))
-      case _ =>
+      case WasmInstr.PositionMark(_) =>
+        // ignore
         ()
-    }
 
-    writeInstrImmediates(instr)
+      case _ =>
+        instr match {
+          case END | ELSE | _: CATCH | CATCH_ALL => b.deindent()
+          case _                                 => ()
+        }
+        b.newLine()
+        b.appendElement(instr.mnemonic)
+        instr match {
+          case instr: StructuredLabeledInstr =>
+            instr.label.foreach(writeLabelIdx(_))
+          case _ =>
+            ()
+        }
 
-    instr match {
-      case _: StructuredLabeledInstr | ELSE | _: CATCH | CATCH_ALL => b.indent()
-      case _                                                       => ()
+        writeInstrImmediates(instr)
+
+        instr match {
+          case _: StructuredLabeledInstr | ELSE | _: CATCH | CATCH_ALL => b.indent()
+          case _                                                       => ()
+        }
     }
   }
 
@@ -419,6 +426,9 @@ class WasmTextWriter {
         writeLabelIdx(labelIdx)
         writeType(from)
         writeType(to)
+
+      case PositionMark(pos) =>
+        throw new AssertionError(s"Unexpected $instr")
     }
   }
 }

--- a/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
+++ b/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
@@ -3,8 +3,8 @@ package wasm.ir2wasm
 import org.scalajs.ir.{Trees => IRTrees}
 import org.scalajs.ir.{Types => IRTypes}
 import org.scalajs.ir.{Names => IRNames}
+import org.scalajs.ir.{ClassKind, Position}
 import org.scalajs.linker.standard.LinkedClass
-import org.scalajs.ir.ClassKind
 
 import wasm.wasm4s._
 import wasm.wasm4s.WasmContext._
@@ -17,6 +17,7 @@ import EmbeddedConstants._
 import TypeTransformer._
 
 object HelperFunctions {
+  private implicit val noPos: Position = Position.NoPosition
 
   def genGlobalHelpers()(implicit ctx: WasmContext): Unit = {
     genStringLiteral()

--- a/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmBuilder.scala
@@ -472,6 +472,8 @@ class WasmBuilder(coreSpec: CoreSpec) {
   }
 
   private def genLoadModuleFunc(clazz: LinkedClass)(implicit ctx: WasmContext): Unit = {
+    implicit val pos = clazz.pos
+
     assert(clazz.kind == ClassKind.ModuleClass)
     val ctor = clazz.methods
       .find(_.methodName.isConstructor)
@@ -934,6 +936,8 @@ class WasmBuilder(coreSpec: CoreSpec) {
   }
 
   private def genLoadJSClassFunction(clazz: LinkedClass)(implicit ctx: WasmContext): Unit = {
+    implicit val pos = clazz.pos
+
     val cachedJSClassGlobal = WasmGlobal(
       WasmGlobalName.forJSClassValue(clazz.className),
       WasmRefType.anyref,
@@ -964,6 +968,8 @@ class WasmBuilder(coreSpec: CoreSpec) {
   }
 
   private def genLoadJSModuleFunction(clazz: LinkedClass)(implicit ctx: WasmContext): Unit = {
+    implicit val pos = clazz.pos
+
     val className = clazz.className
     val cacheGlobalName = WasmGlobalName.forModuleInstance(className)
 
@@ -1005,6 +1011,8 @@ class WasmBuilder(coreSpec: CoreSpec) {
   private def transformTopLevelMethodExportDef(
       exportDef: IRTrees.TopLevelMethodExportDef
   )(implicit ctx: WasmContext): Unit = {
+    implicit val pos = exportDef.pos
+
     val method = exportDef.methodDef
     val exportedName = exportDef.topLevelExportName
 
@@ -1070,6 +1078,8 @@ class WasmBuilder(coreSpec: CoreSpec) {
       clazz: LinkedClass,
       method: IRTrees.MethodDef
   )(implicit ctx: WasmContext): WasmFunction = {
+    implicit val pos = method.pos
+
     val functionName = Names.WasmFunctionName(
       method.flags.namespace,
       clazz.name.name,

--- a/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/SourceMapWriterAccess.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/SourceMapWriterAccess.scala
@@ -1,0 +1,22 @@
+package org.scalajs.linker.backend.webassembly
+
+import java.net.URI
+import java.nio.ByteBuffer
+
+import org.scalajs.linker.backend.javascript.{ByteArrayWriter, SourceMapWriter}
+
+object SourceMapWriterAccess {
+
+  /** A box to hold a `ByteArrayWriter`, which is unfortunately package-private in Scala.js but
+    * required to create a `SourceMapWriter`.
+    */
+  final class ByteArrayWriterBox() {
+    private val underlying = new ByteArrayWriter()
+
+    def createSourceMapWriter(jsFileName: String, relativizeBaseURI: Option[URI]): SourceMapWriter =
+      new SourceMapWriter(underlying, jsFileName, relativizeBaseURI)
+
+    def toByteBuffer(): ByteBuffer =
+      underlying.toByteBuffer()
+  }
+}

--- a/wasm/src/main/scala/wasm4s/Instructions.scala
+++ b/wasm/src/main/scala/wasm4s/Instructions.scala
@@ -1,6 +1,8 @@
 package wasm.wasm4s
 // https://webassembly.github.io/spec/core/syntax/instructions.html
 
+import org.scalajs.ir.Position
+
 import Types._
 import Names._
 import Names.WasmTypeName._
@@ -95,6 +97,9 @@ object WasmInstr {
   ) extends WasmInstr(mnemonic, opcode)
 
   // The actual instruction list
+
+  // Fake instruction to mark position changes
+  final case class PositionMark(pos: Position) extends WasmInstr("pos", -1)
 
   // Unary operations
   case object I32_EQZ extends WasmSimpleInstr("i32.eqz", 0x45)

--- a/wasm/src/main/scala/wasm4s/Wasm.scala
+++ b/wasm/src/main/scala/wasm4s/Wasm.scala
@@ -2,6 +2,8 @@ package wasm.wasm4s
 
 import scala.collection.mutable
 
+import org.scalajs.ir.Position
+
 import Types._
 import Names._
 import Names.WasmTypeName._
@@ -36,7 +38,8 @@ case class WasmFunction(
     val typeName: WasmTypeName,
     val locals: List[WasmLocal],
     val results: List[WasmType],
-    val body: WasmExpr
+    val body: WasmExpr,
+    val pos: Position
 )
 
 /** The index space for locals is only accessible inside a function and includes the parameters of

--- a/wasm/src/main/scala/wasm4s/WasmContext.scala
+++ b/wasm/src/main/scala/wasm4s/WasmContext.scala
@@ -626,7 +626,9 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
     import WasmInstr._
     import WasmTypeName._
 
-    val fctx = WasmFunctionContext(WasmFunctionName.start, Nil, Nil)(this)
+    implicit val pos = Position.NoPosition
+
+    val fctx = WasmFunctionContext(WasmFunctionName.start, Nil, Nil)(this, pos)
 
     import fctx.instrs
 
@@ -719,7 +721,6 @@ class WasmContext(val module: WasmModule) extends TypeDefinableWasmContext {
           WasmFunctionName(IRTrees.MemberNamespace.PublicStatic, className, methodName)
         instrs += WasmInstr.CALL(functionName)
       }
-      implicit val noPos: Position = Position.NoPosition
 
       val stringArrayTypeRef = IRTypes.ArrayTypeRef(IRTypes.ClassRef(IRNames.BoxedStringClass), 1)
 


### PR DESCRIPTION
It turns out that source maps are supported for WebAssembly. Positions in the generated code are interpreted as

* a single line, and
* columns correspond to offsets in the `.wasm` file.

We reuse the Scala.js facility to create source maps per se. We feed it the right data from the binary writer.

To be consistent with how the Scala.js linker works when emitting JavaScript, we define a subclass of `WasmBinaryWriter` that handles source maps in addition of the regular output.

In our model, we store positions as fake `WasmInstr` every time the position (potentially) changes. This is in contrast with the JavaScript backend, which stores a `pos` in every `js.Tree`. There are typically several Wasm instructions that encode any particular `ir.Trees.Tree` (and therefore correspond to one position), so this is probably a better trade-off.