### PR TITLE
Compress interface tables with packed encoding

### DIFF
--- a/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
+++ b/wasm/src/main/scala/ir2wasm/HelperFunctions.scala
@@ -1700,7 +1700,7 @@ object HelperFunctions {
     val itables = fctx.addLocal("itables", WasmRefType.nullable(WasmArrayTypeName.itables))
     val exprNonNullLocal = fctx.addLocal("exprNonNull", WasmRefType.any)
 
-    val itableIdx = ctx.getItableIdx(clazz.name.name)
+    val itableIdx = ctx.getItableIdx(classInfo)
     fctx.block(WasmRefType.anyref) { testFail =>
       // if expr is not an instance of Object, return false
       instrs += LOCAL_GET(exprParam)
@@ -1724,9 +1724,9 @@ object HelperFunctions {
       instrs += LOCAL_GET(itables)
       instrs += I32_CONST(itableIdx)
       instrs += ARRAY_GET(WasmTypeName.WasmArrayTypeName.itables)
-      instrs += BR_ON_NULL(testFail)
-
-      instrs += I32_CONST(1)
+      instrs += REF_TEST(
+        WasmRefType(WasmStructTypeName.forITable(clazz.name.name))
+      )
       instrs += RETURN
     } // test fail
 

--- a/wasm/src/main/scala/ir2wasm/Preprocessor.scala
+++ b/wasm/src/main/scala/ir2wasm/Preprocessor.scala
@@ -28,7 +28,10 @@ object Preprocessor {
 
     for (clazz <- classes) {
       ctx.getClassInfo(clazz.className).buildMethodTable()
+    }
+    ctx.assignBuckets(classes)
 
+    for (clazz <- classes) {
       if (clazz.kind == ClassKind.Interface && clazz.hasInstanceTests)
         HelperFunctions.genInstanceTest(clazz)
       HelperFunctions.genCloneFunction(clazz)
@@ -101,7 +104,8 @@ object Preprocessor {
         !clazz.hasDirectInstances,
         hasRuntimeTypeInfo,
         clazz.jsNativeLoadSpec,
-        clazz.jsNativeMembers.map(m => m.name.name -> m.jsNativeLoadSpec).toMap
+        clazz.jsNativeMembers.map(m => m.name.name -> m.jsNativeLoadSpec).toMap,
+        _itableIdx = -1
       )
     )
 

--- a/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
+++ b/wasm/src/main/scala/ir2wasm/WasmExpressionBuilder.scala
@@ -655,7 +655,7 @@ private class WasmExpressionBuilder private (
   ): Unit = {
     // Generates an itable-based dispatch.
     def genITableDispatch(): Unit = {
-      val itableIdx = ctx.getItableIdx(receiverClassInfo.name)
+      val itableIdx = ctx.getItableIdx(receiverClassInfo)
       val methodIdx = receiverClassInfo.tableMethodInfos(methodName).tableIndex
 
       instrs += LOCAL_GET(receiverLocalForDispatch)


### PR DESCRIPTION
This commit implements the "packed encoding" algorithm for compressing interface tables (itables). The algorithm is based on the paper "Efficient Type Inclusion Tests". https://www.researchgate.net/publication/2438441_Efficient_Type_Inclusion_Tests It compresses the itable by reusing itable indices for unrelated types, reducing the size of the itable array. For scalajs-test-suite, the itable size is reduced from 413 to 47.

This change didn't reduce the size of wasm binary that much (14957kb to 14943kb), but it should be space efficient.

We chose packed encoding because the compression rate is good enough among the presented methods in the paper. While hierarchical encoding is slightly better compression rate, packed encoding is better in both compile-time and runtime performance in CPU and space.