### PR TITLE
Merge `FunctionSignature` and `FunctionType`.

### DIFF
--- a/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
@@ -474,8 +474,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
        * If `expr` is `undefined`, it would be `(1 << 4) == 0b00010000`, which
        * would give `false`.
        */
-      val anyRefToVoidSig =
-        wamod.FunctionSignature(List(watpe.RefType.anyref), Nil)
+      val anyRefToVoidSig = wamod.FunctionType(List(watpe.RefType.anyref), Nil)
 
       instrs.block(anyRefToVoidSig) { isNullLabel =>
         // exprNonNull := expr; branch to isNullLabel if it is null
@@ -1113,8 +1112,8 @@ class ClassEmitter(coreSpec: CoreSpec) {
   /** Generates the function import for a top-level export setter. */
   private def genTopLevelExportSetter(exportedName: String)(implicit ctx: WasmContext): Unit = {
     val functionName = genFunctionName.forTopLevelExportSetter(exportedName)
-    val functionSig = wamod.FunctionSignature(List(watpe.RefType.anyref), Nil)
-    val functionType = ctx.moduleBuilder.signatureToTypeName(functionSig)
+    val functionSig = wamod.FunctionType(List(watpe.RefType.anyref), Nil)
+    val functionType = ctx.moduleBuilder.functionTypeToTypeName(functionSig)
 
     ctx.moduleBuilder.addImport(
       wamod.Import(

--- a/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -194,8 +194,8 @@ object CoreWasmLib {
   }
 
   private def genTags()(implicit ctx: WasmContext): Unit = {
-    val exceptionSig = FunctionSignature(List(RefType.externref), Nil)
-    val typeName = ctx.moduleBuilder.signatureToTypeName(exceptionSig)
+    val exceptionSig = FunctionType(List(RefType.externref), Nil)
+    val typeName = ctx.moduleBuilder.functionTypeToTypeName(exceptionSig)
     ctx.moduleBuilder.addImport(
       Import(
         "__scalaJSHelpers",
@@ -332,8 +332,8 @@ object CoreWasmLib {
         params: List[Type],
         results: List[Type]
     ): Unit = {
-      val sig = FunctionSignature(params, results)
-      val typeName = ctx.moduleBuilder.signatureToTypeName(sig)
+      val sig = FunctionType(params, results)
+      val typeName = ctx.moduleBuilder.functionTypeToTypeName(sig)
       ctx.moduleBuilder.addImport(
         Import("__scalaJSHelpers", name.name, ImportDesc.Func(name, typeName))
       )
@@ -1046,7 +1046,7 @@ object CoreWasmLib {
       // if dims == 0 then
       //   return typeData.arrayOf (which is on the stack)
       instrs += I32Eqz
-      instrs.ifThen(FunctionSignature(List(objectVTableType), List(objectVTableType))) {
+      instrs.ifThen(FunctionType(List(objectVTableType), List(objectVTableType))) {
         instrs += Return
       }
 
@@ -1785,7 +1785,7 @@ object CoreWasmLib {
 
     // componentTypeData := ref_as_non_null(arrayTypeData.componentType)
     // switch (componentTypeData.kind)
-    val switchClauseSig = FunctionSignature(
+    val switchClauseSig = FunctionType(
       List(arrayTypeDataType, itablesType, Int32),
       List(nonNullObjectType)
     )

--- a/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -13,7 +13,7 @@ import org.scalajs.linker.backend.webassembly._
 import org.scalajs.linker.backend.webassembly.{Instructions => wa}
 import org.scalajs.linker.backend.webassembly.{Names => wanme}
 import org.scalajs.linker.backend.webassembly.{Types => watpe}
-import org.scalajs.linker.backend.webassembly.Modules.{FunctionSignature => Sig}
+import org.scalajs.linker.backend.webassembly.Modules.{FunctionType => Sig}
 
 import EmbeddedConstants._
 import SWasmGen._

--- a/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
@@ -31,7 +31,7 @@ final class WasmContext {
   private var _itablesLength: Int = 0
   def itablesLength = _itablesLength
 
-  private val functionTypes = LinkedHashMap.empty[wamod.FunctionSignature, wanme.TypeName]
+  private val functionTypes = LinkedHashMap.empty[wamod.FunctionType, wanme.TypeName]
   private val tableFunctionTypes = mutable.HashMap.empty[MethodName, wanme.TypeName]
   private val constantStringGlobals = LinkedHashMap.empty[String, StringData]
   private val classItableGlobals = mutable.ListBuffer.empty[ClassName]
@@ -39,12 +39,12 @@ final class WasmContext {
   private val reflectiveProxies = LinkedHashMap.empty[MethodName, Int]
 
   val moduleBuilder: ModuleBuilder = {
-    new ModuleBuilder(new ModuleBuilder.FunctionSignatureProvider {
-      def signatureToTypeName(sig: wamod.FunctionSignature): wanme.TypeName = {
+    new ModuleBuilder(new ModuleBuilder.FunctionTypeProvider {
+      def functionTypeToTypeName(sig: wamod.FunctionType): wanme.TypeName = {
         functionTypes.getOrElseUpdate(
           sig, {
             val typeName = genTypeName.forFunction(functionTypes.size)
-            moduleBuilder.addRecType(typeName, wamod.FunctionType(sig))
+            moduleBuilder.addRecType(typeName, sig)
             typeName
           }
         )

--- a/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/ModuleBuilder.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/ModuleBuilder.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 import Names._
 import Modules._
 
-final class ModuleBuilder(functionSignatureProvider: ModuleBuilder.FunctionSignatureProvider) {
+final class ModuleBuilder(functionSignatureProvider: ModuleBuilder.FunctionTypeProvider) {
   import ModuleBuilder._
 
   /** Items are `RecType | RecTypeBuilder`. */
@@ -20,8 +20,8 @@ final class ModuleBuilder(functionSignatureProvider: ModuleBuilder.FunctionSigna
   private val elems: mutable.ListBuffer[Element] = new mutable.ListBuffer()
   private val datas: mutable.ListBuffer[Data] = new mutable.ListBuffer()
 
-  def signatureToTypeName(sig: FunctionSignature): TypeName =
-    functionSignatureProvider.signatureToTypeName(sig)
+  def functionTypeToTypeName(sig: FunctionType): TypeName =
+    functionSignatureProvider.functionTypeToTypeName(sig)
 
   def addRecType(typ: RecType): Unit = types += typ
   def addRecType(typ: SubType): Unit = addRecType(RecType(typ))
@@ -64,8 +64,8 @@ final class ModuleBuilder(functionSignatureProvider: ModuleBuilder.FunctionSigna
 }
 
 object ModuleBuilder {
-  trait FunctionSignatureProvider {
-    def signatureToTypeName(sig: FunctionSignature): TypeName
+  trait FunctionTypeProvider {
+    def functionTypeToTypeName(sig: FunctionType): TypeName
   }
 
   final class RecTypeBuilder {

--- a/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/Modules.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/Modules.scala
@@ -98,22 +98,10 @@ object Modules {
 
   sealed abstract class CompositeType
 
-  final case class FunctionSignature(
-      params: List[Type],
-      results: List[Type]
-  )
-  object FunctionSignature {
-    val NilToNil: FunctionSignature = FunctionSignature(Nil, Nil)
-  }
+  final case class FunctionType(params: List[Type], results: List[Type]) extends CompositeType
 
-  final case class FunctionType(
-      params: List[Type],
-      results: List[Type]
-  ) extends CompositeType
   object FunctionType {
-    def apply(sig: FunctionSignature): FunctionType = {
-      FunctionType(sig.params, sig.results)
-    }
+    val NilToNil: FunctionType = FunctionType(Nil, Nil)
   }
 
   final case class StructType(fields: List[StructField]) extends CompositeType


### PR DESCRIPTION
They were isomorphic anyway, and the Wasm spec only has a notion of function type, even where we previously used function signature.