### PR TITLE
[DO NOT MERGE] Initial memory allocation and WASI support

### DIFF
--- a/sample/src/main/scala/Sample.scala
+++ b/sample/src/main/scala/Sample.scala
@@ -2,6 +2,7 @@ package sample
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
+import _root_.scala.scalajs.wasm.io
 
 object Main {
   @JSExportTopLevel("field")
@@ -9,14 +10,17 @@ object Main {
 
   @JSExportTopLevel("test")
   def test(i: Int): Boolean = {
-    println("Hello")
-    exportedField = 53
-    println(exportedField)
     true
   }
 
   def main(args: Array[String]): Unit = {
-    println("hello world")
+    scala.scalajs.wasm.memory.withAllocator { allocator =>
+      val segment = allocator.allocate(4)
+      segment.setInt(0, 100)
+      val result = segment.getInt(0)
+      println(result)
+    }
+    io.printImpl("Hello from WASI!", newLine = true)
   }
 
   // Tested in SampleTest.scala

--- a/sample/src/main/scala/io.scala
+++ b/sample/src/main/scala/io.scala
@@ -1,0 +1,42 @@
+package scala.scalajs.wasm
+
+object io {
+  def printImpl(message: String, newLine: Boolean): Unit = {
+    scala.scalajs.wasm.memory.withAllocator { allocator =>
+      val bytes = message.toCharArray().map(_.toByte)
+      wasiPrintImpl(allocator, bytes, newLine)
+    }
+  }
+  def wasiPrintImpl(
+      allocator: scala.scalajs.wasm.MemoryAllocator,
+      bytes: Array[Byte],
+      newLine: Boolean
+  ) = {
+    val size = bytes.size
+    val memorySize = size + (if (newLine) 1 else 0)
+    val segment = allocator.allocate(memorySize)
+    for ((b, offset) <- bytes.zipWithIndex) {
+      segment.setByte(offset, b)
+    }
+    if (newLine) {
+      segment.setByte(memorySize - 1, 0x0A)
+    }
+
+    val iovs = allocator.allocate(8)
+    iovs.setInt(0, segment.start)
+    iovs.setInt(4, memorySize)
+
+    val rp0 = allocator.allocate(4)
+
+    val ret = wasi.fdWrite(
+      descriptor = wasi.STDOUT,
+      iovs = iovs.start,
+      iovsLen = 1,
+      rp = rp0.start
+    )
+
+    if (ret != 0) {
+      // TODO: check return pointer's error code
+    }
+  }
+}

--- a/sample/src/main/scala/memory.scala
+++ b/sample/src/main/scala/memory.scala
@@ -1,0 +1,52 @@
+package scala.scalajs.wasm
+
+object memory {
+  def withAllocator(block: MemoryAllocator => Unit): Unit = {
+    val allocator = new MemoryAllocator()
+    try {
+      block(allocator)
+    } finally {
+      allocator.free()
+    }
+  }
+
+  def intrinsic: Nothing = throw new NotImplementedError("This is a stub for wasm intrinsics")
+}
+
+class MemorySegment(val start: Int, val size: Int) {
+  import scala.scalajs.wasm.memory.intrinsic
+  private def validate(offset: Int, requiredBytes: Int): Unit = {
+    require(
+      offset + requiredBytes >= 0 && offset + requiredBytes <= size,
+      s"MemorySegment.validate($requiredBytes) failed, can't available $requiredBytes bytes"
+    )
+  }
+
+  // def getByte(offset: Int): Int = {
+  //   validate(offset, 1)
+  //   _loadByte(offset + start)
+  // }
+  def getInt(offset: Int): Int = {
+    validate(offset, 4)
+    _loadInt(offset + start)
+  }
+
+  def setByte(offset: Int, value: Byte): Unit = {
+    validate(offset, 1)
+    _storeByte(offset + start, value)
+  }
+  def setInt(offset: Int, value: Int): Unit = {
+    validate(offset, 4)
+    _storeInt(offset + start, value)
+  }
+
+  private def _loadInt(offset: Int): Int = intrinsic
+  private def _storeByte(offset: Int, value: Byte): Unit = intrinsic
+  private def _storeInt(offset: Int, value: Int): Unit = intrinsic
+}
+
+class MemoryAllocator { // 1MB default initial size
+  import scala.scalajs.wasm.memory.intrinsic
+  def allocate(size: Int): MemorySegment = intrinsic
+  def free(): Unit = intrinsic
+}

--- a/sample/src/main/scala/wasi.scala
+++ b/sample/src/main/scala/wasi.scala
@@ -1,0 +1,9 @@
+package scala.scalajs.wasm
+
+object wasi {
+  val STDOUT = 1
+  val STDERR = 2
+
+  // "wasi_snapshot_preview1", "fd_write"
+  def fdWrite(descriptor: Int, iovs: Int, iovsLen: Int, rp: Int): Int = ???
+}

--- a/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -74,6 +74,7 @@ const scalaJSHelpers = {
   // undefined
   undef: void 0,
   isUndef: (x) => x === (void 0),
+  print: (x) => console.log(x),
 
   // Zero boxes
   bFalse: false,
@@ -308,12 +309,13 @@ const scalaJSHelpers = {
   },
 }
 
-export async function load(wasmFileURL, importedModules, exportSetters) {
+export async function load(wasmFileURL, importedModules, exportSetters, wasi) {
   const myScalaJSHelpers = { ...scalaJSHelpers, idHashCodeMap: new WeakMap() };
   const importsObj = {
     "__scalaJSHelpers": myScalaJSHelpers,
     "__scalaJSImports": importedModules,
     "__scalaJSExportSetters": exportSetters,
+    "wasi_snapshot_preview1": wasi.wasiImport,
   };
   const resolvedURL = new URL(wasmFileURL, import.meta.url);
   var wasmModulePromise;
@@ -327,7 +329,8 @@ export async function load(wasmFileURL, importedModules, exportSetters) {
   } else {
     wasmModulePromise = WebAssembly.instantiateStreaming(fetch(resolvedURL), importsObj);
   }
-  await wasmModulePromise;
+  const instance = (await wasmModulePromise).instance;
+  wasi.start(instance);
 }
     """
   }

--- a/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/SpecialNames.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/SpecialNames.scala
@@ -26,4 +26,29 @@ object SpecialNames {
 
   /** A unique simple method name to map all method *signatures* into `MethodName`s. */
   val normalizedSimpleMethodName = SimpleMethodName("m")
+
+  // Memory Instructions
+  val WasmMemoryAllocatorClass = ClassName("scala.scalajs.wasm.MemoryAllocator")
+  val WasmMemorySegmentClass = ClassName("scala.scalajs.wasm.MemorySegment")
+  val WasmMemoryAllocatorCtor = MethodName.constructor(Nil)
+  val WasmMemorySegmentCtor = MethodName.constructor(List(IntRef, IntRef))
+
+  val WasmMemorySegmentStartAddressField =
+    FieldName(WasmMemorySegmentClass, SimpleFieldName("start"))
+  val WasmMemorySegmentSizeField = FieldName(WasmMemorySegmentClass, SimpleFieldName("size"))
+  val allocateMethodName =
+    MethodName("allocate", List(IntRef), ClassRef(SpecialNames.WasmMemorySegmentClass))
+  val freeMethodName = MethodName("free", Nil, VoidRef)
+
+  val loadByteMethodName = MethodName("_loadByte", List(IntRef), IntRef)
+  val loadIntMethodName = MethodName("_loadInt", List(IntRef), IntRef)
+  val loadMethodNames = Set(loadByteMethodName, loadIntMethodName)
+
+  val storeByteMethodName = MethodName("_storeByte", List(IntRef, ByteRef), VoidRef)
+  val storeIntMethodName = MethodName("_storeInt", List(IntRef, IntRef), VoidRef)
+  val storeMethodNames = Set(storeIntMethodName, storeByteMethodName)
+
+  // WASI functions
+  val WASI = ClassName("scala.scalajs.wasm.wasi$")
+  val wasiFdWrite = MethodName("fdWrite", List(IntRef, IntRef, IntRef, IntRef), IntRef)
 }

--- a/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -65,6 +65,9 @@ object VarGen {
 
     val idHashCodeMap: GlobalName =
       GlobalName("idHashCodeMap")
+
+    val currentAddress: GlobalName =
+      GlobalName("currentAddress")
   }
 
   object genFunctionName {
@@ -140,6 +143,8 @@ object VarGen {
     val is = make("is")
 
     val isUndef = make("isUndef")
+
+    val print = make("print")
 
     def box(primRef: PrimRef): FunctionName = make("b" + primRef.charCode)
     def unbox(primRef: PrimRef): FunctionName = make("u" + primRef.charCode)
@@ -259,6 +264,13 @@ object VarGen {
     val newArrayObject = make("newArrayObject")
     val identityHashCode = make("identityHashCode")
     val searchReflectiveProxy = make("searchReflectiveProxy")
+    val allocate = make("allocate")
+    val free = make("free")
+
+    // WASI
+    object wasi {
+      val fdWrite = make("fd_write")
+    }
   }
 
   object genFieldName {
@@ -427,6 +439,7 @@ object VarGen {
     val ClassStruct = forClass(ClassClass)
     val ThrowableStruct = forClass(ThrowableClass)
     val JSExceptionStruct = forClass(SpecialNames.JSExceptionClass)
+    val WasmMemorySegment = forClass(SpecialNames.WasmMemorySegmentClass)
 
     def captureData(index: Int): TypeName =
       TypeName(s"captureData.$index")
@@ -517,6 +530,10 @@ object VarGen {
 
   object genDataName {
     val string = DataName("string")
+  }
+
+  object genMemoryName {
+    val mem = MemoryName("mem")
   }
 
 }

--- a/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/Instructions.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/Instructions.scala
@@ -98,6 +98,30 @@ object Instructions {
       val fieldIdx: FieldIdx
   ) extends Instr(mnemonic, opcode)
 
+  sealed abstract class MemoryInstr(
+      mnemonic: String,
+      opcode: Int,
+      val memoryName: MemoryName
+  ) extends Instr(mnemonic, opcode)
+
+  case class MemoryArg private (offset: Int, align: Int)
+  object MemoryArg {
+
+    /** We use 0 for `memarg.align` (an expected alignment) for now. Which means we don't provide no
+      * hint to a WebAssembly implementation regarding the memory alignment, and memory access may
+      * be slower on some hardware. However, unaligned access is still allowed in WebAssembly.
+      *
+      * @see
+      *   https://www.w3.org/TR/wasm-core-2/#memory-instructions%E2%91%A4
+      */
+    def apply(): MemoryArg = MemoryArg(0, 0)
+  }
+  sealed abstract class LoadAndStoreInstr(
+      mnemonic: String,
+      opcode: Int,
+      val memoryArg: MemoryArg
+  ) extends Instr(mnemonic, opcode)
+
   // The actual instruction list
 
   // Fake instruction to mark position changes
@@ -236,6 +260,38 @@ object Instructions {
   case object F64Min extends SimpleInstr("f64.min", 0xA4)
   case object F64Max extends SimpleInstr("f64.max", 0xA5)
 
+  // load
+  case class I32Load(arg: MemoryArg) extends LoadAndStoreInstr("i32.load", 0x28, arg)
+  case class I64Load(arg: MemoryArg) extends LoadAndStoreInstr("i64.load", 0x29, arg)
+  case class F32Load(arg: MemoryArg) extends LoadAndStoreInstr("f32.load", 0x2A, arg)
+  case class F64Load(arg: MemoryArg) extends LoadAndStoreInstr("f64.load", 0x2B, arg)
+  case class I32Load8S(arg: MemoryArg) extends LoadAndStoreInstr("i32.load8_s", 0x2C, arg)
+  case class I32Load8U(arg: MemoryArg) extends LoadAndStoreInstr("i32.load8_u", 0x2D, arg)
+  case class I32Load16S(arg: MemoryArg) extends LoadAndStoreInstr("i32.load16_s", 0x2E, arg)
+  case class I32Load16U(arg: MemoryArg) extends LoadAndStoreInstr("i32.load16_u", 0x2F, arg)
+  case class I64Load8S(arg: MemoryArg) extends LoadAndStoreInstr("i64.load8_s", 0x30, arg)
+  case class I64Load8U(arg: MemoryArg) extends LoadAndStoreInstr("i64.load8_u", 0x31, arg)
+  case class I64Load16S(arg: MemoryArg) extends LoadAndStoreInstr("i64.load16_s", 0x32, arg)
+  case class I64Load16U(arg: MemoryArg) extends LoadAndStoreInstr("i64.load16_u", 0x33, arg)
+  case class I64Load32S(arg: MemoryArg) extends LoadAndStoreInstr("i64.load32_s", 0x34, arg)
+  case class I64Load32U(arg: MemoryArg) extends LoadAndStoreInstr("i64.load32_u", 0x35, arg)
+
+  // store
+  case class I32Store(arg: MemoryArg) extends LoadAndStoreInstr("i32.store", 0x36, arg)
+  case class I64Store(arg: MemoryArg) extends LoadAndStoreInstr("i64.store", 0x37, arg)
+  case class F32Store(arg: MemoryArg) extends LoadAndStoreInstr("f32.store", 0x38, arg)
+  case class F64Store(arg: MemoryArg) extends LoadAndStoreInstr("f64.store", 0x39, arg)
+  case class I32Store8(arg: MemoryArg) extends LoadAndStoreInstr("i32.store8", 0x3A, arg)
+  case class I32Store16(arg: MemoryArg) extends LoadAndStoreInstr("i32.store16", 0x3B, arg)
+  case class I64tore8(arg: MemoryArg) extends LoadAndStoreInstr("i64.store8", 0x3C, arg)
+  case class I64tore16(arg: MemoryArg) extends LoadAndStoreInstr("i64.store16", 0x3D, arg)
+  case class I64tore32(arg: MemoryArg) extends LoadAndStoreInstr("i64.store32", 0x3E, arg)
+
+  // memory
+  case class MemorySize(mem: MemoryName) extends MemoryInstr("memory.size", 0x3F, mem)
+  case class MemoryGrow(mem: MemoryName) extends MemoryInstr("memory.grow", 0x40, mem)
+
+  // const
   case class I32Const(v: Int) extends Instr("i32.const", 0x41)
   case class I64Const(v: Long) extends Instr("i64.const", 0x42)
   case class F32Const(v: Float) extends Instr("f32.const", 0x43)

--- a/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/ModuleBuilder.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/ModuleBuilder.scala
@@ -19,6 +19,7 @@ final class ModuleBuilder(functionSignatureProvider: ModuleBuilder.FunctionTypeP
   private var start: Option[FunctionName] = None
   private val elems: mutable.ListBuffer[Element] = new mutable.ListBuffer()
   private val datas: mutable.ListBuffer[Data] = new mutable.ListBuffer()
+  private val memories: mutable.ListBuffer[Memory] = new mutable.ListBuffer()
 
   def functionTypeToTypeName(sig: FunctionType): TypeName =
     functionSignatureProvider.functionTypeToTypeName(sig)
@@ -40,6 +41,7 @@ final class ModuleBuilder(functionSignatureProvider: ModuleBuilder.FunctionTypeP
   def setStart(startFunction: FunctionName): Unit = start = Some(startFunction)
   def addElement(element: Element): Unit = elems += element
   def addData(data: Data): Unit = datas += data
+  def addMemory(mem: Memory): Unit = memories += mem
 
   def build(): Module = {
     val builtTypes: List[RecType] = types.toList.map { tpe =>
@@ -58,7 +60,8 @@ final class ModuleBuilder(functionSignatureProvider: ModuleBuilder.FunctionTypeP
       exports.toList,
       start,
       elems.toList,
-      datas.toList
+      datas.toList,
+      memories.toList
     )
   }
 }

--- a/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/Modules.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/Modules.scala
@@ -21,6 +21,7 @@ object Modules {
   object Export {
     final case class Function(exportName: String, funcName: FunctionName) extends Export
     final case class Global(exportName: String, globalName: GlobalName) extends Export
+    final case class Memory(exportName: String, memoryName: MemoryName) extends Export
   }
 
   final case class Import(module: String, name: String, desc: ImportDesc)
@@ -55,6 +56,11 @@ object Modules {
   )
 
   final case class Tag(val name: TagName, val typ: TypeName)
+
+  final case class Memory(val name: MemoryName, val limits: Memory.Limits)
+  object Memory {
+    final case class Limits(min: Int, max: Option[Int])
+  }
 
   final case class Data(val name: DataName, val bytes: Array[Byte], mode: Data.Mode)
 
@@ -141,6 +147,7 @@ object Modules {
       val exports: List[Export],
       val start: Option[FunctionName],
       val elems: List[Element],
-      val datas: List[Data]
+      val datas: List[Data],
+      val memories: List[Memory]
   )
 }

--- a/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/Names.scala
+++ b/wasm/src/main/scala/org/scalajs/linker/backend/webassembly/Names.scala
@@ -29,4 +29,6 @@ object Names {
 
   final case class ExportName(name: String) extends Name
 
+  final case class MemoryName(name: String) extends Name
+
 }


### PR DESCRIPTION
This commit adds experimental [WASI preview1](https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md) support (at least `fd_write` for now) via memory instructions.

**Memory Allocation overview**

To allocate memory in Wasm's linear memory, use `MemoryAllocator.allocate(bytes)`. This method returns a `MemorySegment` representing the contiguous memory space. It has methods to get/set values in that memory segment (e.g., `getByte`, `setByte`), which will be compiled into memory operations (e.g., `i32.load8`, `i32.store8`).

Using `withMemoryAllocator`, you can instantiate a `MemoryAllocator` class, and you can allocate memory segments inside the block. When we exit from the block, all allocated memory segments will be freed.

**Memory Allocation implement**

The current `MemoryAllocator` implementation is very basic. It manages a single "current" memory address and allocates a memory segment of N bytes from the current address when `allocate(N)` is called, shifting the current memory address by N bytes. (Alignment are currently not implemented.) When freeing memory, the implementation resets the current memory address to 0.

This implementation has some issues. For example, nesting `withMemoryAllocator` blocks can cause problems, as exiting an inner block will free all allocated memory. To prevent this, we could either prohibit nesting `withMemoryAllocator` or only free memory when exiting all `withMemoryAllocator` blocks.

Alternatively, each allocator could record the memory segments it allocated and only free those segments when `free` is called. While this would be aligned with normal memory allocator, it might be too much for our use, considering all memory allocation/deallocation happens only around the `withMemoryAllocator` scope.

Another concern is multi-threading. However, current Wasm is single-threaded.
While [Wasm thread proposal](https://github.com/WebAssembly/threads) introduces shared memory and atomic load/store instructions, the linear memory for communicating with WASI should be okay to be thread-local.

**WASI Support and Wasm Intrinsic Functions**

Currently only `fd_write` is supported from WASI preview1.

The `fdWrite` method in the `wasi` object is translated to a `fd_write` call from the `wasi_snapshot_preview1` during Wasm compilation. This intrinsic function translation is implemented by matching with the hardcoded class and method names for now. Hardcoding names for all WASI functions could work for supporting only `wasi_preview1`. However, introducing annotations to specify which imported Wasm functions to call (such as `@WasmFunction("wasi_snapshot_preview1" "fd_write")` ? this annotation function body will be swapped into `fd_write` call) would provide better usability, especially for supporting the Wasm component model / WASI preview2.

Similarly, functions like `MemoryAllocator.allocate` and `MemorySegment.set` are also translated into Wasm intrinsic functions during linking, where they are replaced with the corresponding instruction sequences defined in Wasm.

During this process, a temporary data structure called `SWasmTree` is used. This serves as a design prototype for potentially introducing these data structures as SJSIR Node trees in the future, making it easier to work with them.